### PR TITLE
Fix incorrect priority of NetworkRule

### DIFF
--- a/internal/dashboard/suite_test.go
+++ b/internal/dashboard/suite_test.go
@@ -131,8 +131,8 @@ var _ = AfterSuite(func() {
 type request struct {
 	method string
 	path   string
-	query  map[string]string
-	body   string
+	// query  map[string]string
+	body string
 }
 type response struct {
 	statusCode int
@@ -295,10 +295,13 @@ func test_CreateLoginUserSession(id, displayName string, role wsv1alpha1.UserRol
 }
 
 func test_Login(userId string, password string) []*http.Cookie {
-	got, _ := test_HttpSend(nil, request{
-		method: http.MethodPost, path: "/api/v1alpha1/auth/login", body: `{"id": "` + userId + `", "password": "` + password + `"}`,
-	})
-	Expect(http.StatusOK).Should(Equal(got.StatusCode))
+	var got *http.Response
+	Eventually(func() *http.Response {
+		got, _ = test_HttpSend(nil, request{
+			method: http.MethodPost, path: "/api/v1alpha1/auth/login", body: `{"id": "` + userId + `", "password": "` + password + `"}`,
+		})
+		return got
+	}, time.Second*5, time.Millisecond*100).Should(HaveHTTPStatus(http.StatusOK))
 
 	return got.Cookies()
 }

--- a/internal/webhooks/workspace_webhook.go
+++ b/internal/webhooks/workspace_webhook.go
@@ -151,14 +151,12 @@ func (h *WorkspaceValidationWebhookHandler) InjectDecoder(d *admission.Decoder) 
 
 func sortNetworkRule(netRules []wsv1alpha1.NetworkRule) []wsv1alpha1.NetworkRule {
 	sort.SliceStable(netRules, func(i, j int) bool {
-		return *netRules[i].Group < *netRules[j].Group
-	})
-	sort.SliceStable(netRules, func(i, j int) bool {
-		if netRules[i].Group != netRules[j].Group {
-			return false
-		} else {
+		if *netRules[i].Group < *netRules[j].Group {
+			return true
+		} else if *netRules[i].Group == *netRules[j].Group {
 			return netRules[i].HTTPPath > netRules[j].HTTPPath
 		}
+		return false
 	})
 	return netRules
 }


### PR DESCRIPTION
- Fixed and refactored sort condition typos.

    ```
    typo
    if netRules[i].Group != netRules[j].Group {
         ⏬
    if *netRules[i].Group != *netRules[j].Group {
    ```

- suite_test.go was previously missing a commit