### PR TITLE
Fix webhook charts and add `make gen-charts`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ metadata:
 name: webhook-server-cert
 namespace: {{ .Release.Namespace }}
 labels:
-	{{- include "cosmo-controller-manager.labels" . | nindent 4 }}
+  {{- include "cosmo-controller-manager.labels" . | nindent 4 }}
 type: kubernetes.io/tls
 data:
 ca.crt: {{ $$tls.caCert }}
@@ -72,7 +72,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
 labels:
-	{{- include "cosmo-controller-manager.labels" . | nindent 4 }}
+  {{- include "cosmo-controller-manager.labels" . | nindent 4 }}
 name: cosmo-serving-cert
 namespace: {{ .Release.Namespace }}
 spec:
@@ -80,15 +80,15 @@ dnsNames:
 - cosmo-webhook-service.{{ .Release.Namespace }}.svc
 - cosmo-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
 issuerRef:
-	kind: ClusterIssuer
-	name: cosmo-selfsigned-clusterissuer
+  kind: ClusterIssuer
+  name: cosmo-selfsigned-clusterissuer
 secretName: webhook-server-cert
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
 labels:
-	{{- include "cosmo-controller-manager.labels" . | nindent 4 }}
+  {{- include "cosmo-controller-manager.labels" . | nindent 4 }}
 name: cosmo-selfsigned-clusterissuer
 namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/cosmo-controller-manager/crds/cosmo.cosmo-workspace.github.io_instances.yaml
+++ b/charts/cosmo-controller-manager/crds/cosmo.cosmo-workspace.github.io_instances.yaml
@@ -197,9 +197,9 @@ spec:
                                                 it can contain characters disallowed
                                                 from the conventional "path" part
                                                 of a URL as defined by RFC 3986. Paths
-                                                must begin with a '/'. When unspecified,
-                                                all paths from incoming requests are
-                                                matched.
+                                                must begin with a '/' and must be
+                                                present when using PathType with value
+                                                "Exact" or "Prefix".
                                               type: string
                                             pathType:
                                               description: 'PathType determines the
@@ -229,6 +229,7 @@ spec:
                                               type: string
                                           required:
                                           - backend
+                                          - pathType
                                           type: object
                                         type: array
                                         x-kubernetes-list-type: atomic
@@ -258,9 +259,7 @@ spec:
                                       for IANA standard service names (as per RFC-6335
                                       and http://www.iana.org/assignments/service-names).
                                       Non-standard protocols should use prefixed names
-                                      such as mycompany.com/my-custom-protocol. This
-                                      is a beta field that is guarded by the ServiceAppProtocol
-                                      feature gate and enabled by default.
+                                      such as mycompany.com/my-custom-protocol.
                                     type: string
                                   name:
                                     description: The name of this port within the
@@ -331,22 +330,45 @@ spec:
                             is created by the Instance
                           properties:
                             apiVersion:
+                              description: API version of the referent.
                               type: string
                             creationTimestamp:
                               format: date-time
                               type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead
+                                of an entire object, this string should contain a
+                                valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                For example, if the object reference is to a container
+                                within a pod, this would take on a value like: "spec.containers{name}"
+                                (where "name" refers to the name of the container
+                                that triggered the event) or if no container name
+                                is specified "spec.containers[2]" (container with
+                                index 2 in this pod). This syntax is chosen only to
+                                have some well-defined way of referencing a part of
+                                an object. TODO: this design is not final and this
+                                field is subject to change in the future.'
+                              type: string
                             kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                               type: string
                             name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                             namespace:
+                              description: 'Namespace of the referent. More info:
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this
+                                reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                               type: string
                             updateTimestamp:
                               format: date-time
                               type: string
-                          required:
-                          - apiVersion
-                          - kind
                           type: object
                       required:
                       - target
@@ -364,22 +386,45 @@ spec:
                             is created by the Instance
                           properties:
                             apiVersion:
+                              description: API version of the referent.
                               type: string
                             creationTimestamp:
                               format: date-time
                               type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead
+                                of an entire object, this string should contain a
+                                valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                For example, if the object reference is to a container
+                                within a pod, this would take on a value like: "spec.containers{name}"
+                                (where "name" refers to the name of the container
+                                that triggered the event) or if no container name
+                                is specified "spec.containers[2]" (container with
+                                index 2 in this pod). This syntax is chosen only to
+                                have some well-defined way of referencing a part of
+                                an object. TODO: this design is not final and this
+                                field is subject to change in the future.'
+                              type: string
                             kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                               type: string
                             name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                             namespace:
+                              description: 'Namespace of the referent. More info:
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this
+                                reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                               type: string
                             updateTimestamp:
                               format: date-time
                               type: string
-                          required:
-                          - apiVersion
-                          - kind
                           type: object
                       required:
                       - replicas
@@ -411,22 +456,43 @@ spec:
                     by the Instance
                   properties:
                     apiVersion:
+                      description: API version of the referent.
                       type: string
                     creationTimestamp:
                       format: date-time
                       type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.'
+                      type: string
                     kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                       type: string
                     name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
                     namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                       type: string
                     updateTimestamp:
                       format: date-time
                       type: string
-                  required:
-                  - apiVersion
-                  - kind
                   type: object
                 type: array
               templateName:

--- a/charts/cosmo-controller-manager/crds/workspace.cosmo-workspace.github.io_workspaces.yaml
+++ b/charts/cosmo-controller-manager/crds/workspace.cosmo-workspace.github.io_workspaces.yaml
@@ -94,8 +94,7 @@ spec:
             description: WorkspaceStatus has status of Workspace
             properties:
               config:
-                description: Config defines template-dependent or workspace-dependent
-                  configuration metadata for workspace
+                description: Config defines workspace-dependent configuration
                 properties:
                   deploymentName:
                     type: string
@@ -113,22 +112,43 @@ spec:
                   by the Instance
                 properties:
                   apiVersion:
+                    description: API version of the referent.
                     type: string
                   creationTimestamp:
                     format: date-time
                     type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
                   kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                     type: string
                   namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                   updateTimestamp:
                     format: date-time
                     type: string
-                required:
-                - apiVersion
-                - kind
                 type: object
               phase:
                 type: string

--- a/charts/cosmo-controller-manager/templates/webhook.yaml
+++ b/charts/cosmo-controller-manager/templates/webhook.yaml
@@ -13,7 +13,7 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
-  - v1beta1
+  - v1alpha1
   clientConfig:
     caBundle: {{ if not $.Values.enableCertManager -}}{{ $tls.caCert }}{{- else -}}Cg=={{ end }}
     service:
@@ -57,29 +57,7 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta1
-  clientConfig:
-    caBundle: {{ if not $.Values.enableCertManager -}}{{ $tls.caCert }}{{- else -}}Cg=={{ end }}
-    service:
-      name: cosmo-webhook-service
-      namespace: {{ .Release.Namespace }}
-      path: /mutate-workspace-cosmo-workspace-github-io-v1alpha1-workspace
-  failurePolicy: Fail
-  name: mworkspace.kb.io
-  rules:
-  - apiGroups:
-    - workspace.cosmo-workspace.github.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - workspaces
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
+  - v1alpha1
   clientConfig:
     caBundle: {{ if not $.Values.enableCertManager -}}{{ $tls.caCert }}{{- else -}}Cg=={{ end }}
     service:
@@ -99,6 +77,28 @@ webhooks:
     resources:
     - users
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1alpha1
+  clientConfig:
+    caBundle: {{ if not $.Values.enableCertManager -}}{{ $tls.caCert }}{{- else -}}Cg=={{ end }}
+    service:
+      name: cosmo-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-workspace-cosmo-workspace-github-io-v1alpha1-workspace
+  failurePolicy: Fail
+  name: mworkspace.kb.io
+  rules:
+  - apiGroups:
+    - workspace.cosmo-workspace.github.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - workspaces
+  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -113,7 +113,7 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
-  - v1beta1
+  - v1alpha1
   clientConfig:
     caBundle: {{ if not $.Values.enableCertManager -}}{{ $tls.caCert }}{{- else -}}Cg=={{ end }}
     service:
@@ -135,29 +135,7 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta1
-  clientConfig:
-    caBundle: {{ if not $.Values.enableCertManager -}}{{ $tls.caCert }}{{- else -}}Cg=={{ end }}
-    service:
-      name: cosmo-webhook-service
-      namespace: {{ .Release.Namespace }}
-      path: /validate-workspace-cosmo-workspace-github-io-v1alpha1-workspace
-  failurePolicy: Fail
-  name: vworkspace.kb.io
-  rules:
-  - apiGroups:
-    - workspace.cosmo-workspace.github.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - workspaces
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
+  - v1alpha1
   clientConfig:
     caBundle: {{ if not $.Values.enableCertManager -}}{{ $tls.caCert }}{{- else -}}Cg=={{ end }}
     service:
@@ -177,44 +155,66 @@ webhooks:
     resources:
     - users
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1alpha1
+  clientConfig:
+    caBundle: {{ if not $.Values.enableCertManager -}}{{ $tls.caCert }}{{- else -}}Cg=={{ end }}
+    service:
+      name: cosmo-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-workspace-cosmo-workspace-github-io-v1alpha1-workspace
+  failurePolicy: Fail
+  name: vworkspace.kb.io
+  rules:
+  - apiGroups:
+    - workspace.cosmo-workspace.github.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - workspaces
+  sideEffects: None
 ---
 {{- if not $.Values.enableCertManager }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: webhook-server-cert
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "cosmo-controller-manager.labels" . | nindent 4 }}
+name: webhook-server-cert
+namespace: {{ .Release.Namespace }}
+labels:
+	{{- include "cosmo-controller-manager.labels" . | nindent 4 }}
 type: kubernetes.io/tls
 data:
-  ca.crt: {{ $tls.caCert }}
-  tls.crt: {{ $tls.clientCert }}
-  tls.key: {{ $tls.clientKey }}
+ca.crt: {{ $tls.caCert }}
+tls.crt: {{ $tls.clientCert }}
+tls.key: {{ $tls.clientKey }}
 {{- else }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  labels:
-    {{- include "cosmo-controller-manager.labels" . | nindent 4 }}
-  name: cosmo-serving-cert
-  namespace: {{ .Release.Namespace }}
+labels:
+	{{- include "cosmo-controller-manager.labels" . | nindent 4 }}
+name: cosmo-serving-cert
+namespace: {{ .Release.Namespace }}
 spec:
-  dnsNames:
-  - cosmo-webhook-service.{{ .Release.Namespace }}.svc
-  - cosmo-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
-  issuerRef:
-    kind: ClusterIssuer
-    name: cosmo-selfsigned-clusterissuer
-  secretName: webhook-server-cert
+dnsNames:
+- cosmo-webhook-service.{{ .Release.Namespace }}.svc
+- cosmo-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+issuerRef:
+	kind: ClusterIssuer
+	name: cosmo-selfsigned-clusterissuer
+secretName: webhook-server-cert
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  labels:
-    {{- include "cosmo-controller-manager.labels" . | nindent 4 }}
-  name: cosmo-selfsigned-clusterissuer
-  namespace: {{ .Release.Namespace }}
+labels:
+	{{- include "cosmo-controller-manager.labels" . | nindent 4 }}
+name: cosmo-selfsigned-clusterissuer
+namespace: {{ .Release.Namespace }}
 spec:
-  selfSigned: {}
+selfSigned: {}
 {{- end }}

--- a/charts/cosmo-controller-manager/templates/webhook.yaml
+++ b/charts/cosmo-controller-manager/templates/webhook.yaml
@@ -185,7 +185,7 @@ metadata:
 name: webhook-server-cert
 namespace: {{ .Release.Namespace }}
 labels:
-	{{- include "cosmo-controller-manager.labels" . | nindent 4 }}
+  {{- include "cosmo-controller-manager.labels" . | nindent 4 }}
 type: kubernetes.io/tls
 data:
 ca.crt: {{ $tls.caCert }}
@@ -196,7 +196,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
 labels:
-	{{- include "cosmo-controller-manager.labels" . | nindent 4 }}
+  {{- include "cosmo-controller-manager.labels" . | nindent 4 }}
 name: cosmo-serving-cert
 namespace: {{ .Release.Namespace }}
 spec:
@@ -204,15 +204,15 @@ dnsNames:
 - cosmo-webhook-service.{{ .Release.Namespace }}.svc
 - cosmo-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
 issuerRef:
-	kind: ClusterIssuer
-	name: cosmo-selfsigned-clusterissuer
+  kind: ClusterIssuer
+  name: cosmo-selfsigned-clusterissuer
 secretName: webhook-server-cert
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
 labels:
-	{{- include "cosmo-controller-manager.labels" . | nindent 4 }}
+  {{- include "cosmo-controller-manager.labels" . | nindent 4 }}
 name: cosmo-selfsigned-clusterissuer
 namespace: {{ .Release.Namespace }}
 spec:

--- a/config/webhook-chart/kustomization.yaml
+++ b/config/webhook-chart/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- ../webhook
+
+namePrefix: cosmo-

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -50,7 +50,7 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta1
+  - v1alpha1
   clientConfig:
     service:
       name: webhook-service
@@ -121,7 +121,7 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  - v1beta1
+  - v1alpha1
   clientConfig:
     service:
       name: webhook-service

--- a/internal/webhooks/user_webhook.go
+++ b/internal/webhooks/user_webhook.go
@@ -24,7 +24,7 @@ type UserMutationWebhookHandler struct {
 	decoder *admission.Decoder
 }
 
-//+kubebuilder:webhook:path=/mutate-workspace-cosmo-workspace-github-io-v1alpha1-user,mutating=true,failurePolicy=fail,sideEffects=None,groups=workspace.cosmo-workspace.github.io,resources=users,verbs=create;update,versions=v1alpha1,name=muser.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-workspace-cosmo-workspace-github-io-v1alpha1-user,mutating=true,failurePolicy=fail,sideEffects=None,groups=workspace.cosmo-workspace.github.io,resources=users,verbs=create;update,versions=v1alpha1,name=muser.kb.io,admissionReviewVersions={v1,v1alpha1}
 
 func (h *UserMutationWebhookHandler) SetupWebhookWithManager(mgr ctrl.Manager) {
 	mgr.GetWebhookServer().Register(
@@ -116,7 +116,7 @@ type UserValidationWebhookHandler struct {
 	decoder *admission.Decoder
 }
 
-//+kubebuilder:webhook:path=/validate-workspace-cosmo-workspace-github-io-v1alpha1-user,mutating=false,failurePolicy=fail,sideEffects=None,groups=workspace.cosmo-workspace.github.io,resources=users,verbs=create;update,versions=v1alpha1,name=vuser.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-workspace-cosmo-workspace-github-io-v1alpha1-user,mutating=false,failurePolicy=fail,sideEffects=None,groups=workspace.cosmo-workspace.github.io,resources=users,verbs=create;update,versions=v1alpha1,name=vuser.kb.io,admissionReviewVersions={v1,v1alpha1}
 
 func (h *UserValidationWebhookHandler) SetupWebhookWithManager(mgr ctrl.Manager) {
 	mgr.GetWebhookServer().Register(


### PR DESCRIPTION
- fix webhook charts yaml. It was old and diffrent from kubebuilder-generated charts.
- add `make gen-charts` and make it execute every after `make manifests`