### PR TITLE
modify PrintObjectDiff

### DIFF
--- a/pkg/clog/clog.go
+++ b/pkg/clog/clog.go
@@ -110,7 +110,8 @@ func (l *Logger) DumpObject(scheme *apiruntime.Scheme, obj NamedObject, msg stri
 
 func (l *Logger) PrintObjectDiff(x, y interface{}) {
 	if l.logger.Enabled() {
-		PrintObjectDiff(l.out, x, y)
+		diff := Diff(x, y)
+		l.Info(diff)
 	}
 }
 


### PR DESCRIPTION
- Print the log header with printObjectDiff.
- At the time of unit test, the log output order is incorrect.
