### PR TITLE
Port name rename

### DIFF
--- a/internal/cmd/__snapshots__/workspace_test.snap
+++ b/internal/cmd/__snapshots__/workspace_test.snap
@@ -1,12 +1,12 @@
-['cosmoctl [workspace] [close-port] ✅ success in normal context: workspace close-port ws1 --user user1 --port-name nw1 1']
+['cosmoctl [workspace] [add-net-rule] ✅ success in normal context: workspace add-net-rule ws1 --user user1 --name nw11 --port 3000 --path /abc --group gp11 1']
 SnapShot = """
-\u001B[32mSuccessfully closed port 'nw1' for workspace 'ws1'
+\u001B[32mSuccessfully add network rule 'nw11' for workspace 'ws1'
 \u001B[0m"""
 
-['cosmoctl [workspace] [close-port] ✅ success in normal context: workspace close-port ws1 --user user1 --port-name nw1 2']
+['cosmoctl [workspace] [add-net-rule] ✅ success in normal context: workspace add-net-rule ws1 --user user1 --name nw11 --port 3000 --path /abc --group gp11 2']
 SnapShot = 'success'
 
-['cosmoctl [workspace] [close-port] ✅ success in normal context: workspace close-port ws1 --user user1 --port-name nw1 3']
+['cosmoctl [workspace] [add-net-rule] ✅ success in normal context: workspace add-net-rule ws1 --user user1 --name nw11 --port 3000 --path /abc --group gp11 3']
 SnapShot = """
 {
   \"Name\": \"ws1\",
@@ -18,12 +18,30 @@ SnapShot = """
     \"replicas\": 1,
     \"network\": [
       {
-        \"portName\": \"nw2\",
+        \"portName\": \"nw1\",
+        \"portNumber\": 1111,
+        \"httpPath\": \"/\",
+        \"targetPortNumber\": 1111,
+        \"host\": \"default.example.com\",
+        \"group\": \"gp1\",
+        \"public\": false
+      },
+      {
+        \"portName\": \"nw3\",
         \"portNumber\": 2222,
         \"httpPath\": \"/\",
         \"targetPortNumber\": 2222,
         \"host\": \"default.example.com\",
         \"group\": \"gp1\",
+        \"public\": false
+      },
+      {
+        \"portName\": \"nw11\",
+        \"portNumber\": 3000,
+        \"httpPath\": \"/abc\",
+        \"targetPortNumber\": 3000,
+        \"host\": \"default.example.com\",
+        \"group\": \"gp11\",
         \"public\": false
       }
     ]
@@ -39,15 +57,78 @@ SnapShot = """
 }
 """
 
-['cosmoctl [workspace] [close-port] ❌ fail with an unexpected error at update: workspace close-port ws1 --user user1 --port-name nw1 1']
+['cosmoctl [workspace] [add-net-rule] ✅ success in normal context: workspace add-net-rule ws1 --user user1 --name nw12 --port 4000 --path /def 1']
 SnapShot = """
-Error: failed to remove network rule: mock update error
+\u001B[32mSuccessfully add network rule 'nw12' for workspace 'ws1'
+\u001B[0m"""
+
+['cosmoctl [workspace] [add-net-rule] ✅ success in normal context: workspace add-net-rule ws1 --user user1 --name nw12 --port 4000 --path /def 2']
+SnapShot = 'success'
+
+['cosmoctl [workspace] [add-net-rule] ✅ success in normal context: workspace add-net-rule ws1 --user user1 --name nw12 --port 4000 --path /def 3']
+SnapShot = """
+{
+  \"Name\": \"ws1\",
+  \"Namespace\": \"cosmo-user-user1\",
+  \"Spec\": {
+    \"template\": {
+      \"name\": \"template1\"
+    },
+    \"replicas\": 1,
+    \"network\": [
+      {
+        \"portName\": \"nw1\",
+        \"portNumber\": 1111,
+        \"httpPath\": \"/\",
+        \"targetPortNumber\": 1111,
+        \"host\": \"default.example.com\",
+        \"group\": \"gp1\",
+        \"public\": false
+      },
+      {
+        \"portName\": \"nw3\",
+        \"portNumber\": 2222,
+        \"httpPath\": \"/\",
+        \"targetPortNumber\": 2222,
+        \"host\": \"default.example.com\",
+        \"group\": \"gp1\",
+        \"public\": false
+      },
+      {
+        \"portName\": \"nw12\",
+        \"portNumber\": 4000,
+        \"httpPath\": \"/def\",
+        \"targetPortNumber\": 4000,
+        \"host\": \"default.example.com\",
+        \"group\": \"nw12\",
+        \"public\": false
+      }
+    ]
+  },
+  \"Status\": {
+    \"instance\": {},
+    \"phase\": \"Pending\",
+    \"config\": {
+      \"mainServicePortName\": \"main\",
+      \"urlbase\": \"https://default.example.com\"
+    }
+  }
+}
+"""
+
+['cosmoctl [workspace] [add-net-rule] ❌ fail with an unexpected error at update: workspace add-net-rule ws1 --user user1 --name nw12 --port 4000 --path /def 1']
+SnapShot = """
+Error: failed to upsert network rule: mock update error
 Usage:
-  cosmoctl workspace close-port WORKSPACE_NAME --port-name PORT_NAME [flags]
+  cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]
 
 Flags:
-  -h, --help               help for close-port
-      --port-name string   port name (Required)
+      --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
+  -h, --help           help for add-net-rule
+      --name string    network rule name (Required)
+      --path string    path for Ingress path when using ingress (default \"/\")
+      --port int       serivce port number (Required)
+      --public         disable authentication for this port
 
 Global Flags:
   -A, --all-namespaces      all namespaces
@@ -59,18 +140,22 @@ Global Flags:
 
 """
 
-['cosmoctl [workspace] [close-port] ❌ fail with an unexpected error at update: workspace close-port ws1 --user user1 --port-name nw1 2']
-SnapShot = 'failed to remove network rule: mock update error'
+['cosmoctl [workspace] [add-net-rule] ❌ fail with an unexpected error at update: workspace add-net-rule ws1 --user user1 --name nw12 --port 4000 --path /def 2']
+SnapShot = 'failed to upsert network rule: mock update error'
 
-['cosmoctl [workspace] [close-port] ❌ fail with invalid args: workspace close-port 1']
+['cosmoctl [workspace] [add-net-rule] ❌ fail with invalid args: workspace add-net-rule 1']
 SnapShot = """
 Error: validation error: invalid args
 Usage:
-  cosmoctl workspace close-port WORKSPACE_NAME --port-name PORT_NAME [flags]
+  cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]
 
 Flags:
-  -h, --help               help for close-port
-      --port-name string   port name (Required)
+      --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
+  -h, --help           help for add-net-rule
+      --name string    network rule name (Required)
+      --path string    path for Ingress path when using ingress (default \"/\")
+      --port int       serivce port number (Required)
+      --public         disable authentication for this port
 
 Global Flags:
   -A, --all-namespaces      all namespaces
@@ -82,18 +167,22 @@ Global Flags:
 
 """
 
-['cosmoctl [workspace] [close-port] ❌ fail with invalid args: workspace close-port 2']
+['cosmoctl [workspace] [add-net-rule] ❌ fail with invalid args: workspace add-net-rule 2']
 SnapShot = 'validation error: invalid args'
 
-['cosmoctl [workspace] [close-port] ❌ fail with invalid args: workspace close-port ws1 --namespace xxxxx --port-name nw11 1']
+['cosmoctl [workspace] [add-net-rule] ❌ fail with invalid args: workspace add-net-rule ws1 --namespace xxxxx --name nw11 --port 3000 --path / 1']
 SnapShot = """
 Error: invalid options: namespace xxxxx is not cosmo user's namespace
 Usage:
-  cosmoctl workspace close-port WORKSPACE_NAME --port-name PORT_NAME [flags]
+  cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]
 
 Flags:
-  -h, --help               help for close-port
-      --port-name string   port name (Required)
+      --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
+  -h, --help           help for add-net-rule
+      --name string    network rule name (Required)
+      --path string    path for Ingress path when using ingress (default \"/\")
+      --port int       serivce port number (Required)
+      --public         disable authentication for this port
 
 Global Flags:
   -A, --all-namespaces      all namespaces
@@ -105,19 +194,23 @@ Global Flags:
 
 """
 
-['cosmoctl [workspace] [close-port] ❌ fail with invalid args: workspace close-port ws1 --namespace xxxxx --port-name nw11 2']
+['cosmoctl [workspace] [add-net-rule] ❌ fail with invalid args: workspace add-net-rule ws1 --namespace xxxxx --name nw11 --port 3000 --path / 2']
 SnapShot = """
 invalid options: namespace xxxxx is not cosmo user's namespace"""
 
-['cosmoctl [workspace] [close-port] ❌ fail with invalid args: workspace close-port ws1 --user user1 --namespace cosmo-user-user1 --port-name nw11 1']
+['cosmoctl [workspace] [add-net-rule] ❌ fail with invalid args: workspace add-net-rule ws1 --user user1 --name nw1 --port 1111 --path / --group gp1 1']
 SnapShot = """
-Error: validation error: --user and --namespace connot be used at the same time
+Error: no change
 Usage:
-  cosmoctl workspace close-port WORKSPACE_NAME --port-name PORT_NAME [flags]
+  cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]
 
 Flags:
-  -h, --help               help for close-port
-      --port-name string   port name (Required)
+      --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
+  -h, --help           help for add-net-rule
+      --name string    network rule name (Required)
+      --path string    path for Ingress path when using ingress (default \"/\")
+      --port int       serivce port number (Required)
+      --public         disable authentication for this port
 
 Global Flags:
   -A, --all-namespaces      all namespaces
@@ -129,18 +222,22 @@ Global Flags:
 
 """
 
-['cosmoctl [workspace] [close-port] ❌ fail with invalid args: workspace close-port ws1 --user user1 --namespace cosmo-user-user1 --port-name nw11 2']
-SnapShot = 'validation error: --user and --namespace connot be used at the same time'
+['cosmoctl [workspace] [add-net-rule] ❌ fail with invalid args: workspace add-net-rule ws1 --user user1 --name nw1 --port 1111 --path / --group gp1 2']
+SnapShot = 'no change'
 
-['cosmoctl [workspace] [close-port] ❌ fail with invalid args: workspace close-port ws1 --user user1 --port-name main 1']
+['cosmoctl [workspace] [add-net-rule] ❌ fail with invalid args: workspace add-net-rule ws1 --user user1 --name nw11 --path / 1']
 SnapShot = """
-Error: main port cannot be removed
+Error: validation error: --port is required
 Usage:
-  cosmoctl workspace close-port WORKSPACE_NAME --port-name PORT_NAME [flags]
+  cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]
 
 Flags:
-  -h, --help               help for close-port
-      --port-name string   port name (Required)
+      --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
+  -h, --help           help for add-net-rule
+      --name string    network rule name (Required)
+      --path string    path for Ingress path when using ingress (default \"/\")
+      --port int       serivce port number (Required)
+      --public         disable authentication for this port
 
 Global Flags:
   -A, --all-namespaces      all namespaces
@@ -152,18 +249,49 @@ Global Flags:
 
 """
 
-['cosmoctl [workspace] [close-port] ❌ fail with invalid args: workspace close-port ws1 --user user1 --port-name main 2']
-SnapShot = 'main port cannot be removed'
+['cosmoctl [workspace] [add-net-rule] ❌ fail with invalid args: workspace add-net-rule ws1 --user user1 --name nw11 --path / 2']
+SnapShot = 'validation error: --port is required'
 
-['cosmoctl [workspace] [close-port] ❌ fail with invalid args: workspace close-port ws1 --user user1 --port-name nw11 -A 1']
+['cosmoctl [workspace] [add-net-rule] ❌ fail with invalid args: workspace add-net-rule ws1 --user user1 --name nw11 --port 1111 --path / 1']
+SnapShot = """
+Error: port 1111 is already used
+Usage:
+  cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]
+
+Flags:
+      --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
+  -h, --help           help for add-net-rule
+      --name string    network rule name (Required)
+      --path string    path for Ingress path when using ingress (default \"/\")
+      --port int       serivce port number (Required)
+      --public         disable authentication for this port
+
+Global Flags:
+  -A, --all-namespaces      all namespaces
+      --context string      kube-context (default: current context)
+      --kubeconfig string   kubeconfig file path (default: $HOME/.kube/config)
+  -n, --namespace string    namespace
+  -u, --user string         user ID
+  -v, --verbose int         log level. -1:DISABLED, 0:INFO, 1:DEBUG, 2:ALL (default -1)
+
+"""
+
+['cosmoctl [workspace] [add-net-rule] ❌ fail with invalid args: workspace add-net-rule ws1 --user user1 --name nw11 --port 1111 --path / 2']
+SnapShot = 'port 1111 is already used'
+
+['cosmoctl [workspace] [add-net-rule] ❌ fail with invalid args: workspace add-net-rule ws1 --user user1 --name nw11 --port 3000 --path / -A 1']
 SnapShot = """
 Error: validation error: --all-namespaces is not supported in this command
 Usage:
-  cosmoctl workspace close-port WORKSPACE_NAME --port-name PORT_NAME [flags]
+  cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]
 
 Flags:
-  -h, --help               help for close-port
-      --port-name string   port name (Required)
+      --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
+  -h, --help           help for add-net-rule
+      --name string    network rule name (Required)
+      --path string    path for Ingress path when using ingress (default \"/\")
+      --port int       serivce port number (Required)
+      --public         disable authentication for this port
 
 Global Flags:
   -A, --all-namespaces      all namespaces
@@ -175,18 +303,22 @@ Global Flags:
 
 """
 
-['cosmoctl [workspace] [close-port] ❌ fail with invalid args: workspace close-port ws1 --user user1 --port-name nw11 -A 2']
+['cosmoctl [workspace] [add-net-rule] ❌ fail with invalid args: workspace add-net-rule ws1 --user user1 --name nw11 --port 3000 --path / -A 2']
 SnapShot = 'validation error: --all-namespaces is not supported in this command'
 
-['cosmoctl [workspace] [close-port] ❌ fail with invalid args: workspace close-port ws1 --user user1 --port-name xxxx 1']
+['cosmoctl [workspace] [add-net-rule] ❌ fail with invalid args: workspace add-net-rule ws1 --user user1 --namespace cosmo-user-user1 --name nw11 --port 3000 --path / 1']
 SnapShot = """
-Error: port name xxxx is not found
+Error: validation error: --user and --namespace connot be used at the same time
 Usage:
-  cosmoctl workspace close-port WORKSPACE_NAME --port-name PORT_NAME [flags]
+  cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]
 
 Flags:
-  -h, --help               help for close-port
-      --port-name string   port name (Required)
+      --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
+  -h, --help           help for add-net-rule
+      --name string    network rule name (Required)
+      --path string    path for Ingress path when using ingress (default \"/\")
+      --port int       serivce port number (Required)
+      --public         disable authentication for this port
 
 Global Flags:
   -A, --all-namespaces      all namespaces
@@ -198,18 +330,22 @@ Global Flags:
 
 """
 
-['cosmoctl [workspace] [close-port] ❌ fail with invalid args: workspace close-port ws1 --user user1 --port-name xxxx 2']
-SnapShot = 'port name xxxx is not found'
+['cosmoctl [workspace] [add-net-rule] ❌ fail with invalid args: workspace add-net-rule ws1 --user user1 --namespace cosmo-user-user1 --name nw11 --port 3000 --path / 2']
+SnapShot = 'validation error: --user and --namespace connot be used at the same time'
 
-['cosmoctl [workspace] [close-port] ❌ fail with invalid args: workspace close-port ws1 --user user1 1']
+['cosmoctl [workspace] [add-net-rule] ❌ fail with invalid args: workspace add-net-rule ws1 --user user1 --port 3000 --path / 1']
 SnapShot = """
-Error: validation error: port name is required
+Error: validation error: --name is required
 Usage:
-  cosmoctl workspace close-port WORKSPACE_NAME --port-name PORT_NAME [flags]
+  cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]
 
 Flags:
-  -h, --help               help for close-port
-      --port-name string   port name (Required)
+      --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
+  -h, --help           help for add-net-rule
+      --name string    network rule name (Required)
+      --path string    path for Ingress path when using ingress (default \"/\")
+      --port int       serivce port number (Required)
+      --public         disable authentication for this port
 
 Global Flags:
   -A, --all-namespaces      all namespaces
@@ -221,18 +357,22 @@ Global Flags:
 
 """
 
-['cosmoctl [workspace] [close-port] ❌ fail with invalid args: workspace close-port ws1 --user user1 2']
-SnapShot = 'validation error: port name is required'
+['cosmoctl [workspace] [add-net-rule] ❌ fail with invalid args: workspace add-net-rule ws1 --user user1 --port 3000 --path / 2']
+SnapShot = 'validation error: --name is required'
 
-['cosmoctl [workspace] [close-port] ❌ fail with invalid args: workspace close-port ws1 --user xxxxx --port-name nw11 1']
+['cosmoctl [workspace] [add-net-rule] ❌ fail with invalid args: workspace add-net-rule ws1 --user xxxxx --name nw11 --port 3000 --path / 1']
 SnapShot = """
 Error: user is not found: users.workspace.cosmo-workspace.github.io \"xxxxx\" not found
 Usage:
-  cosmoctl workspace close-port WORKSPACE_NAME --port-name PORT_NAME [flags]
+  cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]
 
 Flags:
-  -h, --help               help for close-port
-      --port-name string   port name (Required)
+      --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
+  -h, --help           help for add-net-rule
+      --name string    network rule name (Required)
+      --path string    path for Ingress path when using ingress (default \"/\")
+      --port int       serivce port number (Required)
+      --public         disable authentication for this port
 
 Global Flags:
   -A, --all-namespaces      all namespaces
@@ -244,18 +384,22 @@ Global Flags:
 
 """
 
-['cosmoctl [workspace] [close-port] ❌ fail with invalid args: workspace close-port ws1 --user xxxxx --port-name nw11 2']
+['cosmoctl [workspace] [add-net-rule] ❌ fail with invalid args: workspace add-net-rule ws1 --user xxxxx --name nw11 --port 3000 --path / 2']
 SnapShot = 'user is not found: users.workspace.cosmo-workspace.github.io "xxxxx" not found'
 
-['cosmoctl [workspace] [close-port] ❌ fail with invalid args: workspace close-port xxx --user user1 --port-name nw11 1']
+['cosmoctl [workspace] [add-net-rule] ❌ fail with invalid args: workspace add-net-rule xxx --user user1 --name nw11 --port 3000 --path / 1']
 SnapShot = """
 Error: workspace is not found: workspaces.workspace.cosmo-workspace.github.io \"xxx\" not found
 Usage:
-  cosmoctl workspace close-port WORKSPACE_NAME --port-name PORT_NAME [flags]
+  cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]
 
 Flags:
-  -h, --help               help for close-port
-      --port-name string   port name (Required)
+      --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
+  -h, --help           help for add-net-rule
+      --name string    network rule name (Required)
+      --path string    path for Ingress path when using ingress (default \"/\")
+      --port int       serivce port number (Required)
+      --public         disable authentication for this port
 
 Global Flags:
   -A, --all-namespaces      all namespaces
@@ -267,7 +411,7 @@ Global Flags:
 
 """
 
-['cosmoctl [workspace] [close-port] ❌ fail with invalid args: workspace close-port xxx --user user1 --port-name nw11 2']
+['cosmoctl [workspace] [add-net-rule] ❌ fail with invalid args: workspace add-net-rule xxx --user user1 --name nw11 --port 3000 --path / 2']
 SnapShot = 'workspace is not found: workspaces.workspace.cosmo-workspace.github.io "xxx" not found'
 
 ['cosmoctl [workspace] [create] ✅ success in normal context: workspace create ws1 --user user1 --template template1 --vars HOGE:HOGEHOGE 1']
@@ -1361,15 +1505,15 @@ Global Flags:
 
 """
 
-['cosmoctl [workspace] [open-port] ✅ success in normal context: workspace open-port ws1 --user user1 --name nw11 --port 3000 --path /abc --group gp11 1']
+['cosmoctl [workspace] [remove-net-rule] ✅ success in normal context: workspace remove-net-rule ws1 --user user1 --name nw1 1']
 SnapShot = """
-\u001B[32mSuccessfully open port 'nw11' for workspace 'ws1'
+\u001B[32mSuccessfully remove network rule 'nw1' for workspace 'ws1'
 \u001B[0m"""
 
-['cosmoctl [workspace] [open-port] ✅ success in normal context: workspace open-port ws1 --user user1 --name nw11 --port 3000 --path /abc --group gp11 2']
+['cosmoctl [workspace] [remove-net-rule] ✅ success in normal context: workspace remove-net-rule ws1 --user user1 --name nw1 2']
 SnapShot = 'success'
 
-['cosmoctl [workspace] [open-port] ✅ success in normal context: workspace open-port ws1 --user user1 --name nw11 --port 3000 --path /abc --group gp11 3']
+['cosmoctl [workspace] [remove-net-rule] ✅ success in normal context: workspace remove-net-rule ws1 --user user1 --name nw1 3']
 SnapShot = """
 {
   \"Name\": \"ws1\",
@@ -1381,30 +1525,12 @@ SnapShot = """
     \"replicas\": 1,
     \"network\": [
       {
-        \"portName\": \"nw1\",
-        \"portNumber\": 1111,
-        \"httpPath\": \"/\",
-        \"targetPortNumber\": 1111,
-        \"host\": \"default.example.com\",
-        \"group\": \"gp1\",
-        \"public\": false
-      },
-      {
-        \"portName\": \"nw3\",
+        \"portName\": \"nw2\",
         \"portNumber\": 2222,
         \"httpPath\": \"/\",
         \"targetPortNumber\": 2222,
         \"host\": \"default.example.com\",
         \"group\": \"gp1\",
-        \"public\": false
-      },
-      {
-        \"portName\": \"nw11\",
-        \"portNumber\": 3000,
-        \"httpPath\": \"/abc\",
-        \"targetPortNumber\": 3000,
-        \"host\": \"default.example.com\",
-        \"group\": \"gp11\",
         \"public\": false
       }
     ]
@@ -1420,78 +1546,15 @@ SnapShot = """
 }
 """
 
-['cosmoctl [workspace] [open-port] ✅ success in normal context: workspace open-port ws1 --user user1 --name nw12 --port 4000 --path /def 1']
+['cosmoctl [workspace] [remove-net-rule] ❌ fail with an unexpected error at update: workspace remove-net-rule ws1 --user user1 --name nw1 1']
 SnapShot = """
-\u001B[32mSuccessfully open port 'nw12' for workspace 'ws1'
-\u001B[0m"""
-
-['cosmoctl [workspace] [open-port] ✅ success in normal context: workspace open-port ws1 --user user1 --name nw12 --port 4000 --path /def 2']
-SnapShot = 'success'
-
-['cosmoctl [workspace] [open-port] ✅ success in normal context: workspace open-port ws1 --user user1 --name nw12 --port 4000 --path /def 3']
-SnapShot = """
-{
-  \"Name\": \"ws1\",
-  \"Namespace\": \"cosmo-user-user1\",
-  \"Spec\": {
-    \"template\": {
-      \"name\": \"template1\"
-    },
-    \"replicas\": 1,
-    \"network\": [
-      {
-        \"portName\": \"nw1\",
-        \"portNumber\": 1111,
-        \"httpPath\": \"/\",
-        \"targetPortNumber\": 1111,
-        \"host\": \"default.example.com\",
-        \"group\": \"gp1\",
-        \"public\": false
-      },
-      {
-        \"portName\": \"nw3\",
-        \"portNumber\": 2222,
-        \"httpPath\": \"/\",
-        \"targetPortNumber\": 2222,
-        \"host\": \"default.example.com\",
-        \"group\": \"gp1\",
-        \"public\": false
-      },
-      {
-        \"portName\": \"nw12\",
-        \"portNumber\": 4000,
-        \"httpPath\": \"/def\",
-        \"targetPortNumber\": 4000,
-        \"host\": \"default.example.com\",
-        \"group\": \"nw12\",
-        \"public\": false
-      }
-    ]
-  },
-  \"Status\": {
-    \"instance\": {},
-    \"phase\": \"Pending\",
-    \"config\": {
-      \"mainServicePortName\": \"main\",
-      \"urlbase\": \"https://default.example.com\"
-    }
-  }
-}
-"""
-
-['cosmoctl [workspace] [open-port] ❌ fail with an unexpected error at update: workspace open-port ws1 --user user1 --name nw12 --port 4000 --path /def 1']
-SnapShot = """
-Error: failed to upsert network rule: mock update error
+Error: failed to remove network rule: mock update error
 Usage:
-  cosmoctl workspace open-port WORKSPACE_NAME --name PORT_NAME --port PORT_NUMBER [flags]
+  cosmoctl workspace remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME [flags]
 
 Flags:
-      --group string   Group of ports for URLVar. Ports in the same group are treated as the same domain. set port-name value if empty
-  -h, --help           help for open-port
-      --name string    Serivce port name (Required)
-      --path string    Path for Ingress path when using ingress (default \"/\")
-      --port int       Serivce port number (Required)
-      --public         disable authentication for this port
+  -h, --help          help for remove-net-rule
+      --name string   network rule name (Required)
 
 Global Flags:
   -A, --all-namespaces      all namespaces
@@ -1503,22 +1566,18 @@ Global Flags:
 
 """
 
-['cosmoctl [workspace] [open-port] ❌ fail with an unexpected error at update: workspace open-port ws1 --user user1 --name nw12 --port 4000 --path /def 2']
-SnapShot = 'failed to upsert network rule: mock update error'
+['cosmoctl [workspace] [remove-net-rule] ❌ fail with an unexpected error at update: workspace remove-net-rule ws1 --user user1 --name nw1 2']
+SnapShot = 'failed to remove network rule: mock update error'
 
-['cosmoctl [workspace] [open-port] ❌ fail with invalid args: workspace open-port 1']
+['cosmoctl [workspace] [remove-net-rule] ❌ fail with invalid args: workspace remove-net-rule 1']
 SnapShot = """
 Error: validation error: invalid args
 Usage:
-  cosmoctl workspace open-port WORKSPACE_NAME --name PORT_NAME --port PORT_NUMBER [flags]
+  cosmoctl workspace remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME [flags]
 
 Flags:
-      --group string   Group of ports for URLVar. Ports in the same group are treated as the same domain. set port-name value if empty
-  -h, --help           help for open-port
-      --name string    Serivce port name (Required)
-      --path string    Path for Ingress path when using ingress (default \"/\")
-      --port int       Serivce port number (Required)
-      --public         disable authentication for this port
+  -h, --help          help for remove-net-rule
+      --name string   network rule name (Required)
 
 Global Flags:
   -A, --all-namespaces      all namespaces
@@ -1530,22 +1589,18 @@ Global Flags:
 
 """
 
-['cosmoctl [workspace] [open-port] ❌ fail with invalid args: workspace open-port 2']
+['cosmoctl [workspace] [remove-net-rule] ❌ fail with invalid args: workspace remove-net-rule 2']
 SnapShot = 'validation error: invalid args'
 
-['cosmoctl [workspace] [open-port] ❌ fail with invalid args: workspace open-port ws1 --namespace xxxxx --name nw11 --port 3000 --path / 1']
+['cosmoctl [workspace] [remove-net-rule] ❌ fail with invalid args: workspace remove-net-rule ws1 --namespace xxxxx --name nw11 1']
 SnapShot = """
 Error: invalid options: namespace xxxxx is not cosmo user's namespace
 Usage:
-  cosmoctl workspace open-port WORKSPACE_NAME --name PORT_NAME --port PORT_NUMBER [flags]
+  cosmoctl workspace remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME [flags]
 
 Flags:
-      --group string   Group of ports for URLVar. Ports in the same group are treated as the same domain. set port-name value if empty
-  -h, --help           help for open-port
-      --name string    Serivce port name (Required)
-      --path string    Path for Ingress path when using ingress (default \"/\")
-      --port int       Serivce port number (Required)
-      --public         disable authentication for this port
+  -h, --help          help for remove-net-rule
+      --name string   network rule name (Required)
 
 Global Flags:
   -A, --all-namespaces      all namespaces
@@ -1557,23 +1612,19 @@ Global Flags:
 
 """
 
-['cosmoctl [workspace] [open-port] ❌ fail with invalid args: workspace open-port ws1 --namespace xxxxx --name nw11 --port 3000 --path / 2']
+['cosmoctl [workspace] [remove-net-rule] ❌ fail with invalid args: workspace remove-net-rule ws1 --namespace xxxxx --name nw11 2']
 SnapShot = """
 invalid options: namespace xxxxx is not cosmo user's namespace"""
 
-['cosmoctl [workspace] [open-port] ❌ fail with invalid args: workspace open-port ws1 --user user1 --name nw1 --port 1111 --path / --group gp1 1']
+['cosmoctl [workspace] [remove-net-rule] ❌ fail with invalid args: workspace remove-net-rule ws1 --user user1 --name main 1']
 SnapShot = """
-Error: no change
+Error: main port cannot be removed
 Usage:
-  cosmoctl workspace open-port WORKSPACE_NAME --name PORT_NAME --port PORT_NUMBER [flags]
+  cosmoctl workspace remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME [flags]
 
 Flags:
-      --group string   Group of ports for URLVar. Ports in the same group are treated as the same domain. set port-name value if empty
-  -h, --help           help for open-port
-      --name string    Serivce port name (Required)
-      --path string    Path for Ingress path when using ingress (default \"/\")
-      --port int       Serivce port number (Required)
-      --public         disable authentication for this port
+  -h, --help          help for remove-net-rule
+      --name string   network rule name (Required)
 
 Global Flags:
   -A, --all-namespaces      all namespaces
@@ -1585,76 +1636,18 @@ Global Flags:
 
 """
 
-['cosmoctl [workspace] [open-port] ❌ fail with invalid args: workspace open-port ws1 --user user1 --name nw1 --port 1111 --path / --group gp1 2']
-SnapShot = 'no change'
+['cosmoctl [workspace] [remove-net-rule] ❌ fail with invalid args: workspace remove-net-rule ws1 --user user1 --name main 2']
+SnapShot = 'main port cannot be removed'
 
-['cosmoctl [workspace] [open-port] ❌ fail with invalid args: workspace open-port ws1 --user user1 --name nw11 --path / 1']
-SnapShot = """
-Error: validation error: --port-number is required
-Usage:
-  cosmoctl workspace open-port WORKSPACE_NAME --name PORT_NAME --port PORT_NUMBER [flags]
-
-Flags:
-      --group string   Group of ports for URLVar. Ports in the same group are treated as the same domain. set port-name value if empty
-  -h, --help           help for open-port
-      --name string    Serivce port name (Required)
-      --path string    Path for Ingress path when using ingress (default \"/\")
-      --port int       Serivce port number (Required)
-      --public         disable authentication for this port
-
-Global Flags:
-  -A, --all-namespaces      all namespaces
-      --context string      kube-context (default: current context)
-      --kubeconfig string   kubeconfig file path (default: $HOME/.kube/config)
-  -n, --namespace string    namespace
-  -u, --user string         user ID
-  -v, --verbose int         log level. -1:DISABLED, 0:INFO, 1:DEBUG, 2:ALL (default -1)
-
-"""
-
-['cosmoctl [workspace] [open-port] ❌ fail with invalid args: workspace open-port ws1 --user user1 --name nw11 --path / 2']
-SnapShot = 'validation error: --port-number is required'
-
-['cosmoctl [workspace] [open-port] ❌ fail with invalid args: workspace open-port ws1 --user user1 --name nw11 --port 1111 --path / 1']
-SnapShot = """
-Error: port 1111 is already used
-Usage:
-  cosmoctl workspace open-port WORKSPACE_NAME --name PORT_NAME --port PORT_NUMBER [flags]
-
-Flags:
-      --group string   Group of ports for URLVar. Ports in the same group are treated as the same domain. set port-name value if empty
-  -h, --help           help for open-port
-      --name string    Serivce port name (Required)
-      --path string    Path for Ingress path when using ingress (default \"/\")
-      --port int       Serivce port number (Required)
-      --public         disable authentication for this port
-
-Global Flags:
-  -A, --all-namespaces      all namespaces
-      --context string      kube-context (default: current context)
-      --kubeconfig string   kubeconfig file path (default: $HOME/.kube/config)
-  -n, --namespace string    namespace
-  -u, --user string         user ID
-  -v, --verbose int         log level. -1:DISABLED, 0:INFO, 1:DEBUG, 2:ALL (default -1)
-
-"""
-
-['cosmoctl [workspace] [open-port] ❌ fail with invalid args: workspace open-port ws1 --user user1 --name nw11 --port 1111 --path / 2']
-SnapShot = 'port 1111 is already used'
-
-['cosmoctl [workspace] [open-port] ❌ fail with invalid args: workspace open-port ws1 --user user1 --name nw11 --port 3000 --path / -A 1']
+['cosmoctl [workspace] [remove-net-rule] ❌ fail with invalid args: workspace remove-net-rule ws1 --user user1 --name nw11 -A 1']
 SnapShot = """
 Error: validation error: --all-namespaces is not supported in this command
 Usage:
-  cosmoctl workspace open-port WORKSPACE_NAME --name PORT_NAME --port PORT_NUMBER [flags]
+  cosmoctl workspace remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME [flags]
 
 Flags:
-      --group string   Group of ports for URLVar. Ports in the same group are treated as the same domain. set port-name value if empty
-  -h, --help           help for open-port
-      --name string    Serivce port name (Required)
-      --path string    Path for Ingress path when using ingress (default \"/\")
-      --port int       Serivce port number (Required)
-      --public         disable authentication for this port
+  -h, --help          help for remove-net-rule
+      --name string   network rule name (Required)
 
 Global Flags:
   -A, --all-namespaces      all namespaces
@@ -1666,22 +1659,41 @@ Global Flags:
 
 """
 
-['cosmoctl [workspace] [open-port] ❌ fail with invalid args: workspace open-port ws1 --user user1 --name nw11 --port 3000 --path / -A 2']
+['cosmoctl [workspace] [remove-net-rule] ❌ fail with invalid args: workspace remove-net-rule ws1 --user user1 --name nw11 -A 2']
 SnapShot = 'validation error: --all-namespaces is not supported in this command'
 
-['cosmoctl [workspace] [open-port] ❌ fail with invalid args: workspace open-port ws1 --user user1 --namespace cosmo-user-user1 --name nw11 --port 3000 --path / 1']
+['cosmoctl [workspace] [remove-net-rule] ❌ fail with invalid args: workspace remove-net-rule ws1 --user user1 --name xxxx 1']
+SnapShot = """
+Error: port name xxxx is not found
+Usage:
+  cosmoctl workspace remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME [flags]
+
+Flags:
+  -h, --help          help for remove-net-rule
+      --name string   network rule name (Required)
+
+Global Flags:
+  -A, --all-namespaces      all namespaces
+      --context string      kube-context (default: current context)
+      --kubeconfig string   kubeconfig file path (default: $HOME/.kube/config)
+  -n, --namespace string    namespace
+  -u, --user string         user ID
+  -v, --verbose int         log level. -1:DISABLED, 0:INFO, 1:DEBUG, 2:ALL (default -1)
+
+"""
+
+['cosmoctl [workspace] [remove-net-rule] ❌ fail with invalid args: workspace remove-net-rule ws1 --user user1 --name xxxx 2']
+SnapShot = 'port name xxxx is not found'
+
+['cosmoctl [workspace] [remove-net-rule] ❌ fail with invalid args: workspace remove-net-rule ws1 --user user1 --namespace cosmo-user-user1 --name nw11 1']
 SnapShot = """
 Error: validation error: --user and --namespace connot be used at the same time
 Usage:
-  cosmoctl workspace open-port WORKSPACE_NAME --name PORT_NAME --port PORT_NUMBER [flags]
+  cosmoctl workspace remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME [flags]
 
 Flags:
-      --group string   Group of ports for URLVar. Ports in the same group are treated as the same domain. set port-name value if empty
-  -h, --help           help for open-port
-      --name string    Serivce port name (Required)
-      --path string    Path for Ingress path when using ingress (default \"/\")
-      --port int       Serivce port number (Required)
-      --public         disable authentication for this port
+  -h, --help          help for remove-net-rule
+      --name string   network rule name (Required)
 
 Global Flags:
   -A, --all-namespaces      all namespaces
@@ -1693,22 +1705,18 @@ Global Flags:
 
 """
 
-['cosmoctl [workspace] [open-port] ❌ fail with invalid args: workspace open-port ws1 --user user1 --namespace cosmo-user-user1 --name nw11 --port 3000 --path / 2']
+['cosmoctl [workspace] [remove-net-rule] ❌ fail with invalid args: workspace remove-net-rule ws1 --user user1 --namespace cosmo-user-user1 --name nw11 2']
 SnapShot = 'validation error: --user and --namespace connot be used at the same time'
 
-['cosmoctl [workspace] [open-port] ❌ fail with invalid args: workspace open-port ws1 --user user1 --port 3000 --path / 1']
+['cosmoctl [workspace] [remove-net-rule] ❌ fail with invalid args: workspace remove-net-rule ws1 --user user1 1']
 SnapShot = """
-Error: validation error: --port-name is required
+Error: validation error: network rule name is required
 Usage:
-  cosmoctl workspace open-port WORKSPACE_NAME --name PORT_NAME --port PORT_NUMBER [flags]
+  cosmoctl workspace remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME [flags]
 
 Flags:
-      --group string   Group of ports for URLVar. Ports in the same group are treated as the same domain. set port-name value if empty
-  -h, --help           help for open-port
-      --name string    Serivce port name (Required)
-      --path string    Path for Ingress path when using ingress (default \"/\")
-      --port int       Serivce port number (Required)
-      --public         disable authentication for this port
+  -h, --help          help for remove-net-rule
+      --name string   network rule name (Required)
 
 Global Flags:
   -A, --all-namespaces      all namespaces
@@ -1720,22 +1728,18 @@ Global Flags:
 
 """
 
-['cosmoctl [workspace] [open-port] ❌ fail with invalid args: workspace open-port ws1 --user user1 --port 3000 --path / 2']
-SnapShot = 'validation error: --port-name is required'
+['cosmoctl [workspace] [remove-net-rule] ❌ fail with invalid args: workspace remove-net-rule ws1 --user user1 2']
+SnapShot = 'validation error: network rule name is required'
 
-['cosmoctl [workspace] [open-port] ❌ fail with invalid args: workspace open-port ws1 --user xxxxx --name nw11 --port 3000 --path / 1']
+['cosmoctl [workspace] [remove-net-rule] ❌ fail with invalid args: workspace remove-net-rule ws1 --user xxxxx --name nw11 1']
 SnapShot = """
 Error: user is not found: users.workspace.cosmo-workspace.github.io \"xxxxx\" not found
 Usage:
-  cosmoctl workspace open-port WORKSPACE_NAME --name PORT_NAME --port PORT_NUMBER [flags]
+  cosmoctl workspace remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME [flags]
 
 Flags:
-      --group string   Group of ports for URLVar. Ports in the same group are treated as the same domain. set port-name value if empty
-  -h, --help           help for open-port
-      --name string    Serivce port name (Required)
-      --path string    Path for Ingress path when using ingress (default \"/\")
-      --port int       Serivce port number (Required)
-      --public         disable authentication for this port
+  -h, --help          help for remove-net-rule
+      --name string   network rule name (Required)
 
 Global Flags:
   -A, --all-namespaces      all namespaces
@@ -1747,22 +1751,18 @@ Global Flags:
 
 """
 
-['cosmoctl [workspace] [open-port] ❌ fail with invalid args: workspace open-port ws1 --user xxxxx --name nw11 --port 3000 --path / 2']
+['cosmoctl [workspace] [remove-net-rule] ❌ fail with invalid args: workspace remove-net-rule ws1 --user xxxxx --name nw11 2']
 SnapShot = 'user is not found: users.workspace.cosmo-workspace.github.io "xxxxx" not found'
 
-['cosmoctl [workspace] [open-port] ❌ fail with invalid args: workspace open-port xxx --user user1 --name nw11 --port 3000 --path / 1']
+['cosmoctl [workspace] [remove-net-rule] ❌ fail with invalid args: workspace remove-net-rule xxx --user user1 --name nw11 1']
 SnapShot = """
 Error: workspace is not found: workspaces.workspace.cosmo-workspace.github.io \"xxx\" not found
 Usage:
-  cosmoctl workspace open-port WORKSPACE_NAME --name PORT_NAME --port PORT_NUMBER [flags]
+  cosmoctl workspace remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME [flags]
 
 Flags:
-      --group string   Group of ports for URLVar. Ports in the same group are treated as the same domain. set port-name value if empty
-  -h, --help           help for open-port
-      --name string    Serivce port name (Required)
-      --path string    Path for Ingress path when using ingress (default \"/\")
-      --port int       Serivce port number (Required)
-      --public         disable authentication for this port
+  -h, --help          help for remove-net-rule
+      --name string   network rule name (Required)
 
 Global Flags:
   -A, --all-namespaces      all namespaces
@@ -1774,7 +1774,7 @@ Global Flags:
 
 """
 
-['cosmoctl [workspace] [open-port] ❌ fail with invalid args: workspace open-port xxx --user user1 --name nw11 --port 3000 --path / 2']
+['cosmoctl [workspace] [remove-net-rule] ❌ fail with invalid args: workspace remove-net-rule xxx --user user1 --name nw11 2']
 SnapShot = 'workspace is not found: workspaces.workspace.cosmo-workspace.github.io "xxx" not found'
 
 ['cosmoctl [workspace] [run-instance] ✅ success in normal context: workspace run-instance ws1 --user user1 1']

--- a/internal/cmd/__snapshots__/workspace_test.snap
+++ b/internal/cmd/__snapshots__/workspace_test.snap
@@ -1,3 +1,62 @@
+['cosmoctl [workspace] [add-net-rule] ✅ success in normal context: workspace add-net ws1 --user user1 --name nw12 --port 4000 --path /def 1']
+SnapShot = """
+\u001B[32mSuccessfully add network rule 'nw12' for workspace 'ws1'
+\u001B[0m"""
+
+['cosmoctl [workspace] [add-net-rule] ✅ success in normal context: workspace add-net ws1 --user user1 --name nw12 --port 4000 --path /def 2']
+SnapShot = 'success'
+
+['cosmoctl [workspace] [add-net-rule] ✅ success in normal context: workspace add-net ws1 --user user1 --name nw12 --port 4000 --path /def 3']
+SnapShot = """
+{
+  \"Name\": \"ws1\",
+  \"Namespace\": \"cosmo-user-user1\",
+  \"Spec\": {
+    \"template\": {
+      \"name\": \"template1\"
+    },
+    \"replicas\": 1,
+    \"network\": [
+      {
+        \"portName\": \"nw1\",
+        \"portNumber\": 1111,
+        \"httpPath\": \"/\",
+        \"targetPortNumber\": 1111,
+        \"host\": \"default.example.com\",
+        \"group\": \"gp1\",
+        \"public\": false
+      },
+      {
+        \"portName\": \"nw3\",
+        \"portNumber\": 2222,
+        \"httpPath\": \"/\",
+        \"targetPortNumber\": 2222,
+        \"host\": \"default.example.com\",
+        \"group\": \"gp1\",
+        \"public\": false
+      },
+      {
+        \"portName\": \"nw12\",
+        \"portNumber\": 4000,
+        \"httpPath\": \"/def\",
+        \"targetPortNumber\": 4000,
+        \"host\": \"default.example.com\",
+        \"group\": \"nw12\",
+        \"public\": false
+      }
+    ]
+  },
+  \"Status\": {
+    \"instance\": {},
+    \"phase\": \"Pending\",
+    \"config\": {
+      \"mainServicePortName\": \"main\",
+      \"urlbase\": \"https://default.example.com\"
+    }
+  }
+}
+"""
+
 ['cosmoctl [workspace] [add-net-rule] ✅ success in normal context: workspace add-net-rule ws1 --user user1 --name nw11 --port 3000 --path /abc --group gp11 1']
 SnapShot = """
 \u001B[32mSuccessfully add network rule 'nw11' for workspace 'ws1'
@@ -122,6 +181,9 @@ Error: failed to upsert network rule: mock update error
 Usage:
   cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]
 
+Aliases:
+  add-net-rule, add-net
+
 Flags:
       --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
   -h, --help           help for add-net-rule
@@ -149,6 +211,9 @@ Error: validation error: invalid args
 Usage:
   cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]
 
+Aliases:
+  add-net-rule, add-net
+
 Flags:
       --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
   -h, --help           help for add-net-rule
@@ -175,6 +240,9 @@ SnapShot = """
 Error: invalid options: namespace xxxxx is not cosmo user's namespace
 Usage:
   cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]
+
+Aliases:
+  add-net-rule, add-net
 
 Flags:
       --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
@@ -204,6 +272,9 @@ Error: no change
 Usage:
   cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]
 
+Aliases:
+  add-net-rule, add-net
+
 Flags:
       --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
   -h, --help           help for add-net-rule
@@ -230,6 +301,9 @@ SnapShot = """
 Error: validation error: --port is required
 Usage:
   cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]
+
+Aliases:
+  add-net-rule, add-net
 
 Flags:
       --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
@@ -258,6 +332,9 @@ Error: port 1111 is already used
 Usage:
   cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]
 
+Aliases:
+  add-net-rule, add-net
+
 Flags:
       --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
   -h, --help           help for add-net-rule
@@ -284,6 +361,9 @@ SnapShot = """
 Error: validation error: --all-namespaces is not supported in this command
 Usage:
   cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]
+
+Aliases:
+  add-net-rule, add-net
 
 Flags:
       --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
@@ -312,6 +392,9 @@ Error: validation error: --user and --namespace connot be used at the same time
 Usage:
   cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]
 
+Aliases:
+  add-net-rule, add-net
+
 Flags:
       --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
   -h, --help           help for add-net-rule
@@ -338,6 +421,9 @@ SnapShot = """
 Error: validation error: --name is required
 Usage:
   cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]
+
+Aliases:
+  add-net-rule, add-net
 
 Flags:
       --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
@@ -366,6 +452,9 @@ Error: user is not found: users.workspace.cosmo-workspace.github.io \"xxxxx\" no
 Usage:
   cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]
 
+Aliases:
+  add-net-rule, add-net
+
 Flags:
       --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
   -h, --help           help for add-net-rule
@@ -392,6 +481,9 @@ SnapShot = """
 Error: workspace is not found: workspaces.workspace.cosmo-workspace.github.io \"xxx\" not found
 Usage:
   cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]
+
+Aliases:
+  add-net-rule, add-net
 
 Flags:
       --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
@@ -1546,11 +1638,55 @@ SnapShot = """
 }
 """
 
+['cosmoctl [workspace] [remove-net-rule] ✅ success in normal context: workspace rm-net ws1 --user user1 --name nw1 1']
+SnapShot = """
+\u001B[32mSuccessfully remove network rule 'nw1' for workspace 'ws1'
+\u001B[0m"""
+
+['cosmoctl [workspace] [remove-net-rule] ✅ success in normal context: workspace rm-net ws1 --user user1 --name nw1 2']
+SnapShot = 'success'
+
+['cosmoctl [workspace] [remove-net-rule] ✅ success in normal context: workspace rm-net ws1 --user user1 --name nw1 3']
+SnapShot = """
+{
+  \"Name\": \"ws1\",
+  \"Namespace\": \"cosmo-user-user1\",
+  \"Spec\": {
+    \"template\": {
+      \"name\": \"template1\"
+    },
+    \"replicas\": 1,
+    \"network\": [
+      {
+        \"portName\": \"nw2\",
+        \"portNumber\": 2222,
+        \"httpPath\": \"/\",
+        \"targetPortNumber\": 2222,
+        \"host\": \"default.example.com\",
+        \"group\": \"gp1\",
+        \"public\": false
+      }
+    ]
+  },
+  \"Status\": {
+    \"instance\": {},
+    \"phase\": \"Pending\",
+    \"config\": {
+      \"mainServicePortName\": \"main\",
+      \"urlbase\": \"https://default.example.com\"
+    }
+  }
+}
+"""
+
 ['cosmoctl [workspace] [remove-net-rule] ❌ fail with an unexpected error at update: workspace remove-net-rule ws1 --user user1 --name nw1 1']
 SnapShot = """
 Error: failed to remove network rule: mock update error
 Usage:
   cosmoctl workspace remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME [flags]
+
+Aliases:
+  remove-net-rule, rm-net
 
 Flags:
   -h, --help          help for remove-net-rule
@@ -1575,6 +1711,9 @@ Error: validation error: invalid args
 Usage:
   cosmoctl workspace remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME [flags]
 
+Aliases:
+  remove-net-rule, rm-net
+
 Flags:
   -h, --help          help for remove-net-rule
       --name string   network rule name (Required)
@@ -1597,6 +1736,9 @@ SnapShot = """
 Error: invalid options: namespace xxxxx is not cosmo user's namespace
 Usage:
   cosmoctl workspace remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME [flags]
+
+Aliases:
+  remove-net-rule, rm-net
 
 Flags:
   -h, --help          help for remove-net-rule
@@ -1622,6 +1764,9 @@ Error: main port cannot be removed
 Usage:
   cosmoctl workspace remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME [flags]
 
+Aliases:
+  remove-net-rule, rm-net
+
 Flags:
   -h, --help          help for remove-net-rule
       --name string   network rule name (Required)
@@ -1644,6 +1789,9 @@ SnapShot = """
 Error: validation error: --all-namespaces is not supported in this command
 Usage:
   cosmoctl workspace remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME [flags]
+
+Aliases:
+  remove-net-rule, rm-net
 
 Flags:
   -h, --help          help for remove-net-rule
@@ -1668,6 +1816,9 @@ Error: port name xxxx is not found
 Usage:
   cosmoctl workspace remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME [flags]
 
+Aliases:
+  remove-net-rule, rm-net
+
 Flags:
   -h, --help          help for remove-net-rule
       --name string   network rule name (Required)
@@ -1690,6 +1841,9 @@ SnapShot = """
 Error: validation error: --user and --namespace connot be used at the same time
 Usage:
   cosmoctl workspace remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME [flags]
+
+Aliases:
+  remove-net-rule, rm-net
 
 Flags:
   -h, --help          help for remove-net-rule
@@ -1714,6 +1868,9 @@ Error: validation error: network rule name is required
 Usage:
   cosmoctl workspace remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME [flags]
 
+Aliases:
+  remove-net-rule, rm-net
+
 Flags:
   -h, --help          help for remove-net-rule
       --name string   network rule name (Required)
@@ -1737,6 +1894,9 @@ Error: user is not found: users.workspace.cosmo-workspace.github.io \"xxxxx\" no
 Usage:
   cosmoctl workspace remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME [flags]
 
+Aliases:
+  remove-net-rule, rm-net
+
 Flags:
   -h, --help          help for remove-net-rule
       --name string   network rule name (Required)
@@ -1759,6 +1919,9 @@ SnapShot = """
 Error: workspace is not found: workspaces.workspace.cosmo-workspace.github.io \"xxx\" not found
 Usage:
   cosmoctl workspace remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME [flags]
+
+Aliases:
+  remove-net-rule, rm-net
 
 Flags:
   -h, --help          help for remove-net-rule

--- a/internal/cmd/workspace/add_net_rule.go
+++ b/internal/cmd/workspace/add_net_rule.go
@@ -14,11 +14,11 @@ import (
 	"github.com/cosmo-workspace/cosmo/pkg/cmdutil"
 )
 
-type openPortOption struct {
+type addNetRuleOption struct {
 	*cmdutil.UserNamespacedCliOptions
 
 	WorkspaceName string
-	PortName      string
+	NetRuleName   string
 	PortNumber    int
 	Group         string
 	HTTPPath      string
@@ -27,25 +27,25 @@ type openPortOption struct {
 	rule wsv1alpha1.NetworkRule
 }
 
-func openPortCmd(cliOpt *cmdutil.UserNamespacedCliOptions) *cobra.Command {
-	o := &openPortOption{UserNamespacedCliOptions: cliOpt}
+func addNetRuleCmd(cliOpt *cmdutil.UserNamespacedCliOptions) *cobra.Command {
+	o := &addNetRuleOption{UserNamespacedCliOptions: cliOpt}
 
 	cmd := &cobra.Command{
-		Use:               "open-port WORKSPACE_NAME --name PORT_NAME --port PORT_NUMBER",
-		Short:             "Update or insert workspace network port",
+		Use:               "add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER",
+		Short:             "Update or insert workspace network rule",
 		PersistentPreRunE: o.PreRunE,
 		RunE:              cmdutil.RunEHandler(o.RunE),
 	}
-	cmd.Flags().StringVar(&o.PortName, "name", "", "Serivce port name (Required)")
-	cmd.Flags().IntVar(&o.PortNumber, "port", 0, "Serivce port number (Required)")
-	cmd.Flags().StringVar(&o.Group, "group", "", "Group of ports for URLVar. Ports in the same group are treated as the same domain. set port-name value if empty")
-	cmd.Flags().StringVar(&o.HTTPPath, "path", "/", "Path for Ingress path when using ingress")
+	cmd.Flags().StringVar(&o.NetRuleName, "name", "", "network rule name (Required)")
+	cmd.Flags().IntVar(&o.PortNumber, "port", 0, "serivce port number (Required)")
+	cmd.Flags().StringVar(&o.Group, "group", "", "group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty")
+	cmd.Flags().StringVar(&o.HTTPPath, "path", "/", "path for Ingress path when using ingress")
 	cmd.Flags().BoolVar(&o.Public, "public", false, "disable authentication for this port")
 
 	return cmd
 }
 
-func (o *openPortOption) PreRunE(cmd *cobra.Command, args []string) error {
+func (o *addNetRuleOption) PreRunE(cmd *cobra.Command, args []string) error {
 	if err := o.Validate(cmd, args); err != nil {
 		return fmt.Errorf("validation error: %w", err)
 	}
@@ -55,7 +55,7 @@ func (o *openPortOption) PreRunE(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (o *openPortOption) Validate(cmd *cobra.Command, args []string) error {
+func (o *addNetRuleOption) Validate(cmd *cobra.Command, args []string) error {
 	if o.AllNamespace {
 		return errors.New("--all-namespaces is not supported in this command")
 	}
@@ -65,27 +65,27 @@ func (o *openPortOption) Validate(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("invalid args")
 	}
-	if o.PortName == "" {
-		return errors.New("--port-name is required")
+	if o.NetRuleName == "" {
+		return errors.New("--name is required")
 	}
 	if o.PortNumber == 0 {
-		return errors.New("--port-number is required")
+		return errors.New("--port is required")
 	}
 	return nil
 }
 
-func (o *openPortOption) Complete(cmd *cobra.Command, args []string) error {
+func (o *addNetRuleOption) Complete(cmd *cobra.Command, args []string) error {
 	if err := o.UserNamespacedCliOptions.Complete(cmd, args); err != nil {
 		return err
 	}
 	o.WorkspaceName = args[0]
 
 	if o.Group == "" {
-		o.Group = o.PortName
+		o.Group = o.NetRuleName
 	}
 
 	o.rule = wsv1alpha1.NetworkRule{
-		PortName:   o.PortName,
+		PortName:   o.NetRuleName,
 		PortNumber: o.PortNumber,
 		HTTPPath:   o.HTTPPath,
 		Group:      pointer.String(o.Group),
@@ -94,7 +94,7 @@ func (o *openPortOption) Complete(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (o *openPortOption) RunE(cmd *cobra.Command, args []string) error {
+func (o *addNetRuleOption) RunE(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(o.Ctx, time.Second*10)
 	defer cancel()
 	ctx = clog.IntoContext(ctx, o.Logr)
@@ -106,6 +106,6 @@ func (o *openPortOption) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	cmdutil.PrintfColorInfo(o.Out, "Successfully open port '%s' for workspace '%s'\n", o.PortName, o.WorkspaceName)
+	cmdutil.PrintfColorInfo(o.Out, "Successfully add network rule '%s' for workspace '%s'\n", o.NetRuleName, o.WorkspaceName)
 	return nil
 }

--- a/internal/cmd/workspace/add_net_rule.go
+++ b/internal/cmd/workspace/add_net_rule.go
@@ -33,6 +33,7 @@ func addNetRuleCmd(cliOpt *cmdutil.UserNamespacedCliOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER",
 		Short:             "Update or insert workspace network rule",
+		Aliases:           []string{"add-net"},
 		PersistentPreRunE: o.PreRunE,
 		RunE:              cmdutil.RunEHandler(o.RunE),
 	}

--- a/internal/cmd/workspace/cmd.go
+++ b/internal/cmd/workspace/cmd.go
@@ -29,8 +29,8 @@ use "kubectl describe workspace" or "kubectl describe instance" and see controll
 	workspaceCmd.AddCommand(deleteCmd(o))
 	workspaceCmd.AddCommand(runInstanceCmd(o))
 	workspaceCmd.AddCommand(stopInstanceCmd(o))
-	workspaceCmd.AddCommand(openPortCmd(o))
-	workspaceCmd.AddCommand(closePortCmd(o))
+	workspaceCmd.AddCommand(addNetRuleCmd(o))
+	workspaceCmd.AddCommand(removeNetRuleCmd(o))
 
 	cmd.AddCommand(workspaceCmd)
 }

--- a/internal/cmd/workspace/remove_net_rule.go
+++ b/internal/cmd/workspace/remove_net_rule.go
@@ -12,27 +12,27 @@ import (
 	"github.com/cosmo-workspace/cosmo/pkg/cmdutil"
 )
 
-type closePortOption struct {
+type RemoveNetRuleOption struct {
 	*cmdutil.UserNamespacedCliOptions
 
 	WorkspaceName string
-	PortName      string
+	NetRuleName   string
 }
 
-func closePortCmd(cliOpt *cmdutil.UserNamespacedCliOptions) *cobra.Command {
-	o := &closePortOption{UserNamespacedCliOptions: cliOpt}
+func removeNetRuleCmd(cliOpt *cmdutil.UserNamespacedCliOptions) *cobra.Command {
+	o := &RemoveNetRuleOption{UserNamespacedCliOptions: cliOpt}
 
 	cmd := &cobra.Command{
-		Use:               "close-port WORKSPACE_NAME --port-name PORT_NAME",
-		Short:             "Remove workspace network port",
+		Use:               "remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME",
+		Short:             "Remove workspace network rule",
 		PersistentPreRunE: o.PreRunE,
 		RunE:              cmdutil.RunEHandler(o.RunE),
 	}
-	cmd.Flags().StringVar(&o.PortName, "port-name", "", "port name (Required)")
+	cmd.Flags().StringVar(&o.NetRuleName, "name", "", "network rule name (Required)")
 	return cmd
 }
 
-func (o *closePortOption) PreRunE(cmd *cobra.Command, args []string) error {
+func (o *RemoveNetRuleOption) PreRunE(cmd *cobra.Command, args []string) error {
 	if err := o.Validate(cmd, args); err != nil {
 		return fmt.Errorf("validation error: %w", err)
 	}
@@ -42,7 +42,7 @@ func (o *closePortOption) PreRunE(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (o *closePortOption) Validate(cmd *cobra.Command, args []string) error {
+func (o *RemoveNetRuleOption) Validate(cmd *cobra.Command, args []string) error {
 	if o.AllNamespace {
 		return errors.New("--all-namespaces is not supported in this command")
 	}
@@ -52,13 +52,13 @@ func (o *closePortOption) Validate(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return errors.New("invalid args")
 	}
-	if o.PortName == "" {
-		return errors.New("port name is required")
+	if o.NetRuleName == "" {
+		return errors.New("network rule name is required")
 	}
 	return nil
 }
 
-func (o *closePortOption) Complete(cmd *cobra.Command, args []string) error {
+func (o *RemoveNetRuleOption) Complete(cmd *cobra.Command, args []string) error {
 	if err := o.UserNamespacedCliOptions.Complete(cmd, args); err != nil {
 		return err
 	}
@@ -66,17 +66,17 @@ func (o *closePortOption) Complete(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (o *closePortOption) RunE(cmd *cobra.Command, args []string) error {
+func (o *RemoveNetRuleOption) RunE(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(o.Ctx, time.Second*10)
 	defer cancel()
 	ctx = clog.IntoContext(ctx, o.Logr)
 
 	c := o.Client
 
-	if _, err := c.DeleteNetworkRule(ctx, o.WorkspaceName, o.User, o.PortName); err != nil {
+	if _, err := c.DeleteNetworkRule(ctx, o.WorkspaceName, o.User, o.NetRuleName); err != nil {
 		return err
 	}
 
-	cmdutil.PrintfColorInfo(o.Out, "Successfully closed port '%s' for workspace '%s'\n", o.PortName, o.WorkspaceName)
+	cmdutil.PrintfColorInfo(o.Out, "Successfully remove network rule '%s' for workspace '%s'\n", o.NetRuleName, o.WorkspaceName)
 	return nil
 }

--- a/internal/cmd/workspace/remove_net_rule.go
+++ b/internal/cmd/workspace/remove_net_rule.go
@@ -25,6 +25,7 @@ func removeNetRuleCmd(cliOpt *cmdutil.UserNamespacedCliOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME",
 		Short:             "Remove workspace network rule",
+		Aliases:           []string{"rm-net"},
 		PersistentPreRunE: o.PreRunE,
 		RunE:              cmdutil.RunEHandler(o.RunE),
 	}

--- a/internal/cmd/workspace_test.go
+++ b/internal/cmd/workspace_test.go
@@ -318,7 +318,7 @@ var _ = Describe("cosmoctl [workspace]", func() {
 	})
 
 	//==================================================================================
-	Describe("[open-port]", func() {
+	Describe("[add-net-rule]", func() {
 
 		run_test := func(args ...string) {
 			By("---------------test start----------------")
@@ -341,8 +341,8 @@ var _ = Describe("cosmoctl [workspace]", func() {
 				test_createNetworkRule("user1", "ws1", "nw3", 2222, "gp1", "/")
 				run_test(args...)
 			},
-			Entry(desc, "workspace", "open-port", "ws1", "--user", "user1", "--name", "nw11", "--port", "3000", "--path", "/abc", "--group", "gp11"),
-			Entry(desc, "workspace", "open-port", "ws1", "--user", "user1", "--name", "nw12", "--port", "4000", "--path", "/def"),
+			Entry(desc, "workspace", "add-net-rule", "ws1", "--user", "user1", "--name", "nw11", "--port", "3000", "--path", "/abc", "--group", "gp11"),
+			Entry(desc, "workspace", "add-net-rule", "ws1", "--user", "user1", "--name", "nw12", "--port", "4000", "--path", "/def"),
 		)
 
 		DescribeTable("❌ fail with invalid args:",
@@ -351,16 +351,16 @@ var _ = Describe("cosmoctl [workspace]", func() {
 				test_createNetworkRule("user1", "ws1", "nw1", 1111, "gp1", "/")
 				run_test(args...)
 			},
-			Entry(desc, "workspace", "open-port", "ws1", "--user", "user1", "--name", "nw11", "--port", "3000", "--path", "/", "-A"),
-			Entry(desc, "workspace", "open-port", "ws1", "--user", "user1", "--namespace", "cosmo-user-user1", "--name", "nw11", "--port", "3000", "--path", "/"),
-			Entry(desc, "workspace", "open-port", "ws1", "--namespace", "xxxxx", "--name", "nw11", "--port", "3000", "--path", "/"),
-			Entry(desc, "workspace", "open-port"),
-			Entry(desc, "workspace", "open-port", "ws1", "--user", "user1", "--port", "3000", "--path", "/"),
-			Entry(desc, "workspace", "open-port", "ws1", "--user", "user1", "--name", "nw11", "--path", "/"),
-			Entry(desc, "workspace", "open-port", "ws1", "--user", "xxxxx", "--name", "nw11", "--port", "3000", "--path", "/"),
-			Entry(desc, "workspace", "open-port", "xxx", "--user", "user1", "--name", "nw11", "--port", "3000", "--path", "/"),
-			Entry(desc, "workspace", "open-port", "ws1", "--user", "user1", "--name", "nw11", "--port", "1111", "--path", "/"),
-			Entry(desc, "workspace", "open-port", "ws1", "--user", "user1", "--name", "nw1", "--port", "1111", "--path", "/", "--group", "gp1"),
+			Entry(desc, "workspace", "add-net-rule", "ws1", "--user", "user1", "--name", "nw11", "--port", "3000", "--path", "/", "-A"),
+			Entry(desc, "workspace", "add-net-rule", "ws1", "--user", "user1", "--namespace", "cosmo-user-user1", "--name", "nw11", "--port", "3000", "--path", "/"),
+			Entry(desc, "workspace", "add-net-rule", "ws1", "--namespace", "xxxxx", "--name", "nw11", "--port", "3000", "--path", "/"),
+			Entry(desc, "workspace", "add-net-rule"),
+			Entry(desc, "workspace", "add-net-rule", "ws1", "--user", "user1", "--port", "3000", "--path", "/"),
+			Entry(desc, "workspace", "add-net-rule", "ws1", "--user", "user1", "--name", "nw11", "--path", "/"),
+			Entry(desc, "workspace", "add-net-rule", "ws1", "--user", "xxxxx", "--name", "nw11", "--port", "3000", "--path", "/"),
+			Entry(desc, "workspace", "add-net-rule", "xxx", "--user", "user1", "--name", "nw11", "--port", "3000", "--path", "/"),
+			Entry(desc, "workspace", "add-net-rule", "ws1", "--user", "user1", "--name", "nw11", "--port", "1111", "--path", "/"),
+			Entry(desc, "workspace", "add-net-rule", "ws1", "--user", "user1", "--name", "nw1", "--port", "1111", "--path", "/", "--group", "gp1"),
 		)
 
 		DescribeTable("❌ fail with an unexpected error at update:",
@@ -374,12 +374,12 @@ var _ = Describe("cosmoctl [workspace]", func() {
 				}
 				run_test(args...)
 			},
-			Entry(desc, "workspace", "open-port", "ws1", "--user", "user1", "--name", "nw12", "--port", "4000", "--path", "/def"),
+			Entry(desc, "workspace", "add-net-rule", "ws1", "--user", "user1", "--name", "nw12", "--port", "4000", "--path", "/def"),
 		)
 	})
 
 	//==================================================================================
-	Describe("[close-port]", func() {
+	Describe("[remove-net-rule]", func() {
 
 		run_test := func(args ...string) {
 			By("---------------test start----------------")
@@ -402,7 +402,7 @@ var _ = Describe("cosmoctl [workspace]", func() {
 				test_createNetworkRule("user1", "ws1", "nw2", 2222, "gp1", "/")
 				run_test(args...)
 			},
-			Entry(desc, "workspace", "close-port", "ws1", "--user", "user1", "--port-name", "nw1"),
+			Entry(desc, "workspace", "remove-net-rule", "ws1", "--user", "user1", "--name", "nw1"),
 		)
 
 		DescribeTable("❌ fail with invalid args:",
@@ -411,15 +411,15 @@ var _ = Describe("cosmoctl [workspace]", func() {
 				test_createNetworkRule("user1", "ws1", "nw1", 1111, "gp1", "/")
 				run_test(args...)
 			},
-			Entry(desc, "workspace", "close-port", "ws1", "--user", "user1", "--port-name", "nw11", "-A"),
-			Entry(desc, "workspace", "close-port", "ws1", "--user", "user1", "--namespace", "cosmo-user-user1", "--port-name", "nw11"),
-			Entry(desc, "workspace", "close-port", "ws1", "--namespace", "xxxxx", "--port-name", "nw11"),
-			Entry(desc, "workspace", "close-port"),
-			Entry(desc, "workspace", "close-port", "ws1", "--user", "user1"),
-			Entry(desc, "workspace", "close-port", "ws1", "--user", "xxxxx", "--port-name", "nw11"),
-			Entry(desc, "workspace", "close-port", "xxx", "--user", "user1", "--port-name", "nw11"),
-			Entry(desc, "workspace", "close-port", "ws1", "--user", "user1", "--port-name", "main"),
-			Entry(desc, "workspace", "close-port", "ws1", "--user", "user1", "--port-name", "xxxx"),
+			Entry(desc, "workspace", "remove-net-rule", "ws1", "--user", "user1", "--name", "nw11", "-A"),
+			Entry(desc, "workspace", "remove-net-rule", "ws1", "--user", "user1", "--namespace", "cosmo-user-user1", "--name", "nw11"),
+			Entry(desc, "workspace", "remove-net-rule", "ws1", "--namespace", "xxxxx", "--name", "nw11"),
+			Entry(desc, "workspace", "remove-net-rule"),
+			Entry(desc, "workspace", "remove-net-rule", "ws1", "--user", "user1"),
+			Entry(desc, "workspace", "remove-net-rule", "ws1", "--user", "xxxxx", "--name", "nw11"),
+			Entry(desc, "workspace", "remove-net-rule", "xxx", "--user", "user1", "--name", "nw11"),
+			Entry(desc, "workspace", "remove-net-rule", "ws1", "--user", "user1", "--name", "main"),
+			Entry(desc, "workspace", "remove-net-rule", "ws1", "--user", "user1", "--name", "xxxx"),
 		)
 
 		DescribeTable("❌ fail with an unexpected error at update:",
@@ -429,7 +429,7 @@ var _ = Describe("cosmoctl [workspace]", func() {
 				clientMock.SetUpdateError("\\.RunE$", errors.New("mock update error"))
 				run_test(args...)
 			},
-			Entry(desc, "workspace", "close-port", "ws1", "--user", "user1", "--port-name", "nw1"),
+			Entry(desc, "workspace", "remove-net-rule", "ws1", "--user", "user1", "--name", "nw1"),
 		)
 	})
 

--- a/internal/cmd/workspace_test.go
+++ b/internal/cmd/workspace_test.go
@@ -343,6 +343,7 @@ var _ = Describe("cosmoctl [workspace]", func() {
 			},
 			Entry(desc, "workspace", "add-net-rule", "ws1", "--user", "user1", "--name", "nw11", "--port", "3000", "--path", "/abc", "--group", "gp11"),
 			Entry(desc, "workspace", "add-net-rule", "ws1", "--user", "user1", "--name", "nw12", "--port", "4000", "--path", "/def"),
+			Entry(desc, "workspace", "add-net", "ws1", "--user", "user1", "--name", "nw12", "--port", "4000", "--path", "/def"),
 		)
 
 		DescribeTable("❌ fail with invalid args:",
@@ -403,6 +404,7 @@ var _ = Describe("cosmoctl [workspace]", func() {
 				run_test(args...)
 			},
 			Entry(desc, "workspace", "remove-net-rule", "ws1", "--user", "user1", "--name", "nw1"),
+			Entry(desc, "workspace", "rm-net", "ws1", "--user", "user1", "--name", "nw1"),
 		)
 
 		DescribeTable("❌ fail with invalid args:",


### PR DESCRIPTION
- close #356
- change command name in workspace cmd
  - open-port -> add-net-rule, add-net
  - close-port -> remove-net-rule, rm-net
 - change flag name
   - --port-name -> --name 

```
$ cosmoctl ws add-net-rule --help
Update or insert workspace network rule

Usage:
  cosmoctl workspace add-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME --port PORT_NUMBER [flags]

Aliases:
  add-net-rule, add-net

Flags:
      --group string   group of ports for URLVar. Ports in the same group are treated as the same domain. set 'name' value if empty
  -h, --help           help for add-net-rule
      --name string    network rule name (Required)
      --path string    path for Ingress path when using ingress (default "/")
      --port int       serivce port number (Required)
      --public         disable authentication for this port

Global Flags:
  -A, --all-namespaces      all namespaces
      --context string      kube-context (default: current context)
      --kubeconfig string   kubeconfig file path (default: $HOME/.kube/config)
  -n, --namespace string    namespace
  -u, --user string         user ID
  -v, --verbose int         log level. -1:DISABLED, 0:INFO, 1:DEBUG, 2:ALL (default -1)
```

```
$ cosmoctl ws remove-net-rule --help
Remove workspace network rule

Usage:
  cosmoctl workspace remove-net-rule WORKSPACE_NAME --name NETWORK_RULE_NAME [flags]

Aliases:
  remove-net-rule, rm-net

Flags:
  -h, --help          help for remove-net-rule
      --name string   network rule name (Required)

Global Flags:
  -A, --all-namespaces      all namespaces
      --context string      kube-context (default: current context)
      --kubeconfig string   kubeconfig file path (default: $HOME/.kube/config)
  -n, --namespace string    namespace
  -u, --user string         user ID
  -v, --verbose int         log level. -1:DISABLED, 0:INFO, 1:DEBUG, 2:ALL (default -1)
```