### PR TITLE
Update helm chart

### DIFF
--- a/charts/cosmo-controller-manager/templates/manager.yaml
+++ b/charts/cosmo-controller-manager/templates/manager.yaml
@@ -4,11 +4,13 @@ data:
     apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
     kind: ControllerManagerConfig
     health:
-      healthProbeBindAddress: :8081
+      healthProbeBindAddress: :{{ .Values.healthzPort }}
+    {{- if .Values.metrics.enabled }}
     metrics:
-      bindAddress: 127.0.0.1:8080
+      bindAddress: 127.0.0.1:{{ .Values.metrics.port }}
+    {{- end }}
     webhook:
-      port: 9443
+      port: {{ .Values.webhookPort }}
     leaderElection:
       leaderElect: true
       resourceName: 04c57811.cosmo-workspace.github.io
@@ -19,6 +21,7 @@ metadata:
   name: cosmo-manager-config
   namespace: {{ .Release.Namespace }}
 ---
+{{- if .Values.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -29,10 +32,11 @@ metadata:
 spec:
   ports:
   - name: https
-    port: 8443
-    targetPort: https
+    port: {{ .Values.metrics.kubeRbacProxy.port }}
+    targetPort: {{ if .Values.metrics.kubeRbacProxy.enabled -}}{{ .Values.metrics.kubeRbacProxy.port }}{{- else -}}{{ .Values.metrics.port }}{{ end }}
   selector:
     {{- include "cosmo-controller-manager.selectorLabels" . | nindent 4 }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -44,7 +48,7 @@ metadata:
 spec:
   ports:
   - port: 443
-    targetPort: 9443
+    targetPort: {{ .Values.webhookPort }}
   {{- if not .Values.localRunTest.enabled }}
   selector:
     {{- include "cosmo-controller-manager.selectorLabels" . | nindent 4 }}
@@ -92,8 +96,14 @@ spec:
     spec:
       containers:
       - args:
-        - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
+        - --health-probe-bind-address=:{{ .Values.healthzPort }}
+        {{- if and (.Values.metrics.enabled) (.Values.metrics.kubeRbacProxy.enabled) }}
+        - --metrics-bind-address=127.0.0.1:{{ $.Values.metrics.port }}
+        {{- else if and (.Values.metrics.enabled) (not .Values.metrics.kubeRbacProxy.enabled) }}
+        - --metrics-bind-address=0.0.0.0:{{ $.Values.metrics.port }}
+        {{- else }}
+        - --metrics-bind-address=0
+        {{- end }}
         - --leader-elect
         - --zap-log-level={{ .Values.logLevel }}
         {{- if ne .Values.logLevel "info" }}
@@ -107,18 +117,23 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8081
+            port: {{ .Values.healthzPort }}
           initialDelaySeconds: 15
           periodSeconds: 20
         name: manager
         ports:
-        - containerPort: 9443
+        - containerPort: {{ .Values.webhookPort }}
           name: webhook-server
           protocol: TCP
+        {{- if and (.Values.metrics.enabled) (not .Values.metrics.kubeRbacProxy.enabled) }}
+        - containerPort: {{ .Values.metrics.port }}
+          name: metrics
+          protocol: TCP
+        {{- end }}
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 8081
+            port: {{ .Values.healthzPort }}
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
@@ -129,21 +144,29 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+      {{- if and (.Values.metrics.enabled) (.Values.metrics.kubeRbacProxy.enabled) }}
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
+        - --secure-listen-address=0.0.0.0:{{ .Values.metrics.kubeRbacProxy.port }}
+        - --upstream=http://127.0.0.1:{{ .Values.metrics.port }}/
         - --logtostderr=true
         - --v=10
-        image: {{ .Values.imageK8sRbacProxy.repository }}:{{ .Values.imageK8sRbacProxy.tag }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ .Values.metrics.kubeRbacProxy.image.repository }}:{{ .Values.metrics.kubeRbacProxy.image.tag }}
+        imagePullPolicy: {{ .Values.metrics.kubeRbacProxy.image.pullPolicy }}
         name: kube-rbac-proxy
         ports:
-        - containerPort: 8443
+        - containerPort: {{ .Values.metrics.kubeRbacProxy.port }}
           name: https
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
+      {{- end }}
+      {{- if .Values.hostNetwork }}
+      hostNetwork: true
+      {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "cosmo-controller-manager.serviceAccountName" . }}

--- a/charts/cosmo-controller-manager/values.yaml
+++ b/charts/cosmo-controller-manager/values.yaml
@@ -10,11 +10,6 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-imageK8sRbacProxy:
-  repository: gcr.io/kubebuilder/kube-rbac-proxy
-  pullPolicy: IfNotPresent
-  tag: "v0.8.0"
-
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -59,7 +54,32 @@ affinity: {}
 
 logLevel: info
 
+# if false, generate webhook certificate by helm function
 enableCertManager: true
+
+# Specifies if cosmo-controller-manager should be started in hostNetwork mode.
+# set true when using custom CNI and kubeapiserver cannot reach to the webhook endpoint
+hostNetwork: false
+
+# This may need to be used to be changed given certain conditions. For instance, if one uses the cilium CNI
+# with certain settings, one may need to set `hostNetwork: true` and webhooks won't work unless `dnsPolicy`
+# is set to `ClusterFirstWithHostNet`. See https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+dnsPolicy:
+
+# if `hostNetwork: true` set available host ports
+webhookPort: 9443
+healthzPort: 8081
+
+metrics:
+  enabled: true
+  port: 8080
+  kubeRbacProxy:
+    enabled: true
+    port: 8443
+    image:
+      repository: gcr.io/kubebuilder/kube-rbac-proxy
+      pullPolicy: IfNotPresent
+      tag: "v0.8.0"
 
 defaultURLBase:
   # this values are passed to the entrypoint args as follows


### PR DESCRIPTION
- customizable ports
- support hostNetwork mode
- be able to disable metrics

BREAKING CHANGE: `imageK8sRbacProxy` in value.yaml was moved to `metrics.kubeRbacProxy.image` 