### PR TITLE
Add metrics endpoint on cosmo-auth-proxy

### DIFF
--- a/docs/THIRD-PARTY-LICENCE.md
+++ b/docs/THIRD-PARTY-LICENCE.md
@@ -35,34 +35,35 @@
 
 ## Go Library (used in go.mod)
 
-|             software             |       license        |                                licence url                                |
-| :------------------------------- | :------------------- | ------------------------------------------------------------------------- |
-| github.com/evanphx/json-patch/v5 | BSD 3-Clause License | https://github.com/evanphx/json-patch/blob/master/LICENSE                 |
-| github.com/go-logr/logr          | Apache License 2.0   | https://github.com/go-logr/logr/blob/master/LICENSE                       |
-| github.com/google/gofuzz         | Apache License 2.0   | https://github.com/google/gofuzz/blob/master/LICENSE                      |
-| github.com/google/uuid           | BSD 3-Clause License | https://github.com/google/uuid/blob/master/LICENSE                        |
-| github.com/gorilla/mux           | BSD 3-Clause License | https://github.com/gorilla/mux/blob/master/LICENSE                        |
-| github.com/gorilla/securecookie  | BSD 3-Clause License | https://github.com/gorilla/securecookie/blob/master/LICENSE               |
-| github.com/gorilla/sessions      | BSD 3-Clause License | https://github.com/gorilla/sessions/blob/master/LICENSE                   |
-| github.com/mattn/go-isatty       | MIT                  | https://github.com/mattn/go-isatty/blob/master/LICENSE                    |
-| github.com/onsi/ginkgo           | MIT                  | https://github.com/onsi/ginkgo/blob/master/LICENSE                        |
-| github.com/onsi/gomega           | MIT                  | https://github.com/onsi/gomega/blob/master/LICENSE                        |
-| github.com/pelletier/go-toml     | MIT                  | https://github.com/pelletier/go-toml/blob/v2/LICENSE                      |
-| github.com/sethvargo/go-password | MIT                  | https://github.com/sethvargo/go-password/blob/main/LICENSE                |
-| github.com/spf13/cobra           | Apache License 2.0   | https://github.com/spf13/cobra/blob/master/LICENSE.txt                    |
-| github.com/spf13/afero           | Apache License 2.0   | https://github.com/spf13/afero/blob/master/LICENSE.txt                    |
-| go.uber.org/zap                  | MIT                  | https://github.com/uber-go/zap/blob/master/LICENSE.txt                    |
-| golang.org/x/crypto              | BSD 3-Clause License | https://cs.opensource.google/go/x/crypto/+/master:LICENSE                 |
-| golang.org/x/tools               | BSD 3-Clause License | https://cs.opensource.google/go/x/tools/+/master:LICENSE                  |
-| k8s.io/api                       | Apache License 2.0   | https://github.com/kubernetes/api/blob/master/LICENSE                     |
-| k8s.io/apiextensions-apiserver   | Apache License 2.0   | https://github.com/kubernetes/apiextensions-apiserver/blob/master/LICENSE |
-| k8s.io/apimachinery              | Apache License 2.0   | https://github.com/kubernetes/apimachinery/blob/master/LICENSE            |
-| k8s.io/cli-runtime               | Apache License 2.0   | https://github.com/kubernetes/cli-runtime/blob/master/LICENSE             |
-| k8s.io/client-go                 | Apache License 2.0   | https://github.com/kubernetes/client-go/blob/master/LICENSE               |
-| k8s.io/utils                     | Apache License 2.0   | https://github.com/kubernetes/utils/blob/master/LICENSE                   |
-| sigs.k8s.io/controller-runtime   | Apache License 2.0   | https://github.com/kubernetes-sigs/controller-runtime/blob/master/LICENSE |
-| sigs.k8s.io/kustomize/api        | Apache License 2.0   | https://github.com/kubernetes-sigs/kustomize/blob/master/LICENSE          |
-| sigs.k8s.io/yaml                 | MIT                  | https://github.com/kubernetes-sigs/yaml/blob/master/LICENSE               |
+|             software                |       license        |                                licence url                                |
+| :---------------------------------- | :------------------- | ------------------------------------------------------------------------- |
+| github.com/evanphx/json-patch/v5    | BSD 3-Clause License | https://github.com/evanphx/json-patch/blob/master/LICENSE                 |
+| github.com/go-logr/logr             | Apache License 2.0   | https://github.com/go-logr/logr/blob/master/LICENSE                       |
+| github.com/google/gofuzz            | Apache License 2.0   | https://github.com/google/gofuzz/blob/master/LICENSE                      |
+| github.com/google/uuid              | BSD 3-Clause License | https://github.com/google/uuid/blob/master/LICENSE                        |
+| github.com/gorilla/mux              | BSD 3-Clause License | https://github.com/gorilla/mux/blob/master/LICENSE                        |
+| github.com/gorilla/securecookie     | BSD 3-Clause License | https://github.com/gorilla/securecookie/blob/master/LICENSE               |
+| github.com/gorilla/sessions         | BSD 3-Clause License | https://github.com/gorilla/sessions/blob/master/LICENSE                   |
+| github.com/mattn/go-isatty          | MIT                  | https://github.com/mattn/go-isatty/blob/master/LICENSE                    |
+| github.com/onsi/ginkgo              | MIT                  | https://github.com/onsi/ginkgo/blob/master/LICENSE                        |
+| github.com/onsi/gomega              | MIT                  | https://github.com/onsi/gomega/blob/master/LICENSE                        |
+| github.com/pelletier/go-toml        | MIT                  | https://github.com/pelletier/go-toml/blob/v2/LICENSE                      |
+| github.com/sethvargo/go-password    | MIT                  | https://github.com/sethvargo/go-password/blob/main/LICENSE                |
+| github.com/spf13/cobra              | Apache License 2.0   | https://github.com/spf13/cobra/blob/master/LICENSE.txt                    |
+| github.com/spf13/afero              | Apache License 2.0   | https://github.com/spf13/afero/blob/master/LICENSE.txt                    |
+| go.uber.org/zap                     | MIT                  | https://github.com/uber-go/zap/blob/master/LICENSE.txt                    |
+| golang.org/x/crypto                 | BSD 3-Clause License | https://cs.opensource.google/go/x/crypto/+/master:LICENSE                 |
+| golang.org/x/tools                  | BSD 3-Clause License | https://cs.opensource.google/go/x/tools/+/master:LICENSE                  |
+| k8s.io/api                          | Apache License 2.0   | https://github.com/kubernetes/api/blob/master/LICENSE                     |
+| k8s.io/apiextensions-apiserver      | Apache License 2.0   | https://github.com/kubernetes/apiextensions-apiserver/blob/master/LICENSE |
+| k8s.io/apimachinery                 | Apache License 2.0   | https://github.com/kubernetes/apimachinery/blob/master/LICENSE            |
+| k8s.io/cli-runtime                  | Apache License 2.0   | https://github.com/kubernetes/cli-runtime/blob/master/LICENSE             |
+| k8s.io/client-go                    | Apache License 2.0   | https://github.com/kubernetes/client-go/blob/master/LICENSE               |
+| k8s.io/utils                        | Apache License 2.0   | https://github.com/kubernetes/utils/blob/master/LICENSE                   |
+| sigs.k8s.io/controller-runtime      | Apache License 2.0   | https://github.com/kubernetes-sigs/controller-runtime/blob/master/LICENSE |
+| sigs.k8s.io/kustomize/api           | Apache License 2.0   | https://github.com/kubernetes-sigs/kustomize/blob/master/LICENSE          |
+| sigs.k8s.io/yaml                    | MIT                  | https://github.com/kubernetes-sigs/yaml/blob/master/LICENSE               |
+| github.com/prometheus/client_golang | Apache License 2.0   | https://github.com/prometheus/client_golang/blob/main/LICENSE              |
 
 ## Others
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.2.0
 	github.com/onsi/gomega v1.20.2
 	github.com/pelletier/go-toml/v2 v2.0.5
+	github.com/prometheus/client_golang v1.13.1
 	github.com/sethvargo/go-password v0.2.0
 	github.com/spf13/afero v1.9.2
 	github.com/spf13/cobra v1.5.0
@@ -65,7 +66,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.13.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -285,8 +285,8 @@ github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5Fsn
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
-github.com/prometheus/client_golang v1.13.0 h1:b71QUfeo5M8gq2+evJdTPfZhYMAU0uKPkyPJ7TPsloU=
-github.com/prometheus/client_golang v1.13.0/go.mod h1:vTeo+zgvILHsnnj/39Ou/1fPN5nJFOEMgftOUOmlvYQ=
+github.com/prometheus/client_golang v1.13.1 h1:3gMjIY2+/hzmqhtUC/aQNYldJA6DtH3CgQvwS+02K1c=
+github.com/prometheus/client_golang v1.13.1/go.mod h1:vTeo+zgvILHsnnj/39Ou/1fPN5nJFOEMgftOUOmlvYQ=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/web/auth-proxy-ui/README.md
+++ b/web/auth-proxy-ui/README.md
@@ -44,7 +44,7 @@ yarn build --base=/proxy-driver-test --outDir=build_test
 COSMO_USER_ID=xxxxxxxx
 pkill -ef "main echo-server" ; \
 go run ../../hack/echo-server/main.go echo-server &  \
-go run ../../hack/proxy-driver/main.go --port=9999 --target-port=8888 --user=${COSMO_USER_ID} --auth-ui=./build_test/ --auth-url=http://cosmo-dashboard.cosmo-system.svc.cluster.local:8443 ; \
+go run ../../hack/proxy-driver/main.go --port=9999 --target-port=8888 --user=${COSMO_USER_ID} --auth-ui=./build_test/ --auth-url=https://cosmo-dashboard.cosmo-system.svc.cluster.local:8443 ; \
 pkill -ef "main echo-server"
 
 curl  -v  -H "Content-Type: application/json" -d '{"id":"xxxxxxxx","password":"yyyyyyy"}' \


### PR DESCRIPTION
Close #3

Add new endpoint `/metrics` on each local-port proxy servers.

```sh
$ curl http://localhost:37637/metrics
# HELP cosmo_authproxy_proxy_connections Current number of active connections.
# TYPE cosmo_authproxy_proxy_connections gauge
cosmo_authproxy_proxy_connections 2
# HELP cosmo_authproxy_proxy_requests_total Total number of authenticated requests by HTTP status code.
# TYPE cosmo_authproxy_proxy_requests_total counter
cosmo_authproxy_proxy_requests_total{code="200"} 21
cosmo_authproxy_proxy_requests_total{code="304"} 95
# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
# TYPE promhttp_metric_handler_requests_in_flight gauge
promhttp_metric_handler_requests_in_flight 1
# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
# TYPE promhttp_metric_handler_requests_total counter
promhttp_metric_handler_requests_total{code="200"} 3
promhttp_metric_handler_requests_total{code="500"} 0
promhttp_metric_handler_requests_total{code="503"} 0
```